### PR TITLE
Исправлен вызов send_media_to_telegram

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,5 @@ piexif==1.1.3
 minio==7.2.5
 sqlalchemy==2.0.41
 pymysql==1.1.1
+pytest==8.2.2
+pytest-asyncio==0.23.6

--- a/telegram_auto_poster/bot/commands.py
+++ b/telegram_auto_poster/bot/commands.py
@@ -302,9 +302,14 @@ async def send_luba_command(update: Update, context: ContextTypes.DEFAULT_TYPE) 
                 if ext.lower() in [".mp4", ".avi", ".mov"]:
                     media_type = "video"
 
-                # Use helper function to send media
+                # Отправляем медиа без подписи, включая поддержку потокового
+                # воспроизведения для видео
                 await send_media_to_telegram(
-                    context.bot, LUBA_CHAT, temp_path, media_type, object_name
+                    context.bot,
+                    LUBA_CHAT,
+                    temp_path,
+                    caption=None,
+                    supports_streaming=(media_type == "video"),
                 )
                 sent_count += 1
                 await asyncio.sleep(1)  # Rate limiting

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -1,0 +1,120 @@
+import asyncio
+from types import SimpleNamespace
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# Подменяем модули, которые при импорте пытаются подключиться к внешним
+# сервисам (база данных и MinIO).
+dummy_stats_module = SimpleNamespace(stats=SimpleNamespace())
+dummy_storage = SimpleNamespace()
+dummy_storage.list_files = lambda bucket: []
+dummy_storage_module = SimpleNamespace(storage=dummy_storage)
+sys.modules.setdefault('telegram_auto_poster.utils.stats', dummy_stats_module)
+sys.modules.setdefault('telegram_auto_poster.utils.storage', dummy_storage_module)
+
+from telegram_auto_poster.bot.commands import send_luba_command
+
+
+class DummyMessage:
+    def __init__(self):
+        self.texts = []
+
+    async def reply_text(self, text):
+        self.texts.append(text)
+
+
+class DummyUpdate:
+    def __init__(self, user_id=1):
+        self.effective_user = SimpleNamespace(id=user_id)
+        self.message = DummyMessage()
+        self.effective_message = self.message
+
+
+class DummyContext:
+    def __init__(self):
+        self.bot = object()
+        self.bot_data = {}
+
+
+@pytest.mark.asyncio
+async def test_send_luba_command_sends_media(monkeypatch):
+    update = DummyUpdate()
+    context = DummyContext()
+
+    # Prepare mocks
+    monkeypatch.setattr(
+        'telegram_auto_poster.bot.commands.check_admin_rights',
+        lambda u, c: asyncio.Future()
+    )
+    check_future = asyncio.Future()
+    check_future.set_result(True)
+    monkeypatch.setattr(
+        'telegram_auto_poster.bot.commands.check_admin_rights',
+        lambda u, c: check_future,
+    )
+
+    monkeypatch.setattr(
+        'telegram_auto_poster.bot.commands.storage.list_files',
+        lambda bucket: ['a.jpg', 'b.mp4'],
+    )
+
+    async def fake_download(name, bucket):
+        ext = '.mp4' if name.endswith('.mp4') else '.jpg'
+        return f'/tmp/{name}', ext
+
+    monkeypatch.setattr(
+        'telegram_auto_poster.bot.commands.download_from_minio',
+        fake_download,
+    )
+
+    send_calls = []
+
+    async def fake_send(bot, chat_id, file_path, caption=None, supports_streaming=True):
+        send_calls.append((bot, chat_id, file_path, caption, supports_streaming))
+
+    monkeypatch.setattr(
+        'telegram_auto_poster.bot.commands.send_media_to_telegram',
+        fake_send,
+    )
+
+    monkeypatch.setattr('telegram_auto_poster.bot.commands.cleanup_temp_file', lambda p: None)
+    monkeypatch.setattr('telegram_auto_poster.bot.commands.asyncio.sleep', lambda s: asyncio.Future())
+    sleep_future = asyncio.Future()
+    sleep_future.set_result(None)
+    monkeypatch.setattr(
+        'telegram_auto_poster.bot.commands.asyncio.sleep',
+        lambda s: sleep_future,
+    )
+
+    await send_luba_command(update, context)
+
+    assert len(send_calls) == 2
+    assert send_calls[0][4] is False
+    assert send_calls[1][4] is True
+    assert update.message.texts[-1].startswith('Sent 2 files')
+
+
+@pytest.mark.asyncio
+async def test_send_luba_command_no_files(monkeypatch):
+    update = DummyUpdate()
+    context = DummyContext()
+
+    future = asyncio.Future()
+    future.set_result(True)
+    monkeypatch.setattr(
+        'telegram_auto_poster.bot.commands.check_admin_rights',
+        lambda u, c: future,
+    )
+
+    monkeypatch.setattr(
+        'telegram_auto_poster.bot.commands.storage.list_files',
+        lambda bucket: [],
+    )
+
+    await send_luba_command(update, context)
+
+    assert update.message.texts[-1] == 'No files to send to Luba.'


### PR DESCRIPTION
## Изменения
- обновлён вызов `send_media_to_telegram` в `send_luba_command`
- добавлены зависимости для тестирования
- создан набор тестов `test_commands.py`

## Проверка
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6865a74633a0832e8f115ec3b9d61f8b