### PR TITLE
refactor: use configured paths for MinIO

### DIFF
--- a/telegram_auto_poster/bot/callbacks.py
+++ b/telegram_auto_poster/bot/callbacks.py
@@ -56,9 +56,8 @@ async def schedule_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) 
         return
 
     file_name = os.path.basename(file_path)
-    "photo" if file_path.startswith("photos/") else "video"
     file_prefix = (
-        PHOTOS_PATH + "/" if file_path.startswith("photos/") else VIDEOS_PATH + "/"
+        f"{PHOTOS_PATH}/" if file_path.startswith(f"{PHOTOS_PATH}/") else f"{VIDEOS_PATH}/"
     )
 
     try:
@@ -83,7 +82,7 @@ async def schedule_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) 
                     file_prefix + file_name, BUCKET_MAIN
                 )
                 try:
-                    if file_path.startswith("photos/"):
+                    if file_path.startswith(f"{PHOTOS_PATH}/"):
                         media_hash = calculate_image_hash(temp_path)
                     else:
                         media_hash = calculate_video_hash(temp_path)
@@ -137,9 +136,9 @@ async def ok_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         return
 
     file_name = os.path.basename(file_path)
-    media_type = "photo" if file_path.startswith("photos/") else "video"
+    media_type = "photo" if file_path.startswith(f"{PHOTOS_PATH}/") else "video"
     file_prefix = (
-        PHOTOS_PATH + "/" if file_path.startswith("photos/") else VIDEOS_PATH + "/"
+        f"{PHOTOS_PATH}/" if file_path.startswith(f"{PHOTOS_PATH}/") else f"{VIDEOS_PATH}/"
     )
 
     try:
@@ -329,9 +328,9 @@ async def push_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
         return
 
     file_name = os.path.basename(file_path)
-    media_type = "photo" if file_path.startswith("photos/") else "video"
+    media_type = "photo" if file_path.startswith(f"{PHOTOS_PATH}/") else "video"
     file_prefix = (
-        PHOTOS_PATH + "/" if file_path.startswith("photos/") else VIDEOS_PATH + "/"
+        f"{PHOTOS_PATH}/" if file_path.startswith(f"{PHOTOS_PATH}/") else f"{VIDEOS_PATH}/"
     )
 
     try:
@@ -440,14 +439,14 @@ async def notok_callback(update, context) -> None:
             return
 
         file_name = os.path.basename(file_path)
-        media_type = "photo" if file_path.startswith("photos/") else "video"
+        media_type = "photo" if file_path.startswith(f"{PHOTOS_PATH}/") else "video"
 
         await query.message.edit_caption(
             f"Post disapproved with media {file_name}!", reply_markup=None
         )
 
         file_prefix = (
-            PHOTOS_PATH + "/" if file_path.startswith("photos/") else VIDEOS_PATH + "/"
+            f"{PHOTOS_PATH}/" if file_path.startswith(f"{PHOTOS_PATH}/") else f"{VIDEOS_PATH}/"
         )
         # Get user metadata
         user_metadata = storage.get_submission_metadata(file_name)

--- a/telegram_auto_poster/bot/handlers.py
+++ b/telegram_auto_poster/bot/handlers.py
@@ -252,7 +252,7 @@ async def process_photo(
 
         await add_watermark_to_image(
             input_path,
-            f"photos/{processed_name}",
+            processed_name,
             user_metadata=user_metadata,
             media_hash=media_hash,
         )
@@ -303,7 +303,9 @@ async def process_photo(
             await application.bot.send_photo(
                 bot_chat_id,
                 open(temp_path, "rb"),
-                custom_text + "\nNew post found\n" + f"photos/{processed_name}",
+                custom_text
+                + "\nNew post found\n"
+                + f"{PHOTOS_PATH}/{processed_name}",
                 reply_markup=keyboard,
                 read_timeout=60,
                 write_timeout=60,
@@ -402,7 +404,7 @@ async def process_video(
                     video=media_file,
                     caption=custom_text
                     + "\nNew post found\n"
-                    + f"videos/{processed_name}",
+                    + f"{VIDEOS_PATH}/{processed_name}",
                     supports_streaming=True,
                     reply_markup=keyboard,
                     read_timeout=60,

--- a/telegram_auto_poster/utils/__init__.py
+++ b/telegram_auto_poster/utils/__init__.py
@@ -5,6 +5,7 @@ from typing import Any, Optional, Tuple
 
 from loguru import logger
 from telegram.error import BadRequest, NetworkError, TimedOut
+from telegram_auto_poster.config import PHOTOS_PATH, VIDEOS_PATH
 
 # Import stats and storage modules but expose their singletons under distinct
 # names so the submodules remain importable as
@@ -57,9 +58,11 @@ def extract_filename(text: str) -> Optional[str]:
         return None
 
     # Look for lines containing file paths
+    photo_prefix = f"{PHOTOS_PATH}/"
+    video_prefix = f"{VIDEOS_PATH}/"
     for line in reversed(lines):
         if any(
-            path_prefix in line for path_prefix in ["photos/", "videos/", "downloaded_"]
+            path_prefix in line for path_prefix in [photo_prefix, video_prefix, "downloaded_"]
         ):
             return line.strip()
 


### PR DESCRIPTION
## Summary
- use `PHOTOS_PATH` and `VIDEOS_PATH` constants instead of hardcoded prefixes
- fix MinIO path handling in handlers and callbacks
- base filename extraction now respects configured prefixes

## Testing
- `pytest -q` *(fails: No module named 'loguru')*

------
https://chatgpt.com/codex/tasks/task_b_689ddc98d47c832e9faed986f5374716