### PR TITLE
refactor: use absolute imports

### DIFF
--- a/telegram_auto_poster/bot/bot.py
+++ b/telegram_auto_poster/bot/bot.py
@@ -14,7 +14,7 @@ from telegram.ext import (
 from telegram_auto_poster.utils.timezone import now_utc
 
 # Import callbacks from callbacks.py
-from .callbacks import (
+from telegram_auto_poster.bot.callbacks import (
     notok_callback,
     ok_callback,
     push_callback,
@@ -23,7 +23,7 @@ from .callbacks import (
 )
 
 # Import commands from commands.py
-from .commands import (
+from telegram_auto_poster.bot.commands import (
     daily_stats_callback,
     delete_batch_command,
     get_chat_id_command,
@@ -41,7 +41,7 @@ from .commands import (
 )
 
 # Import media handlers from handlers.py
-from .handlers import handle_media
+from telegram_auto_poster.bot.handlers import handle_media
 
 
 class TelegramMemeBot:

--- a/telegram_auto_poster/bot/handlers.py
+++ b/telegram_auto_poster/bot/handlers.py
@@ -18,20 +18,20 @@ from telegram_auto_poster.utils import (
     download_from_minio,
 )
 
-from ..config import (
+from telegram_auto_poster.config import (
     BUCKET_MAIN,
     PHOTOS_PATH,
     VIDEOS_PATH,
 )
-from ..media.photo import add_watermark_to_image
-from ..media.video import add_watermark_to_video
-from ..utils.deduplication import (
+from telegram_auto_poster.media.photo import add_watermark_to_image
+from telegram_auto_poster.media.video import add_watermark_to_video
+from telegram_auto_poster.utils.deduplication import (
     calculate_image_hash,
     calculate_video_hash,
     is_duplicate_hash,
 )
-from ..utils.stats import stats
-from ..utils.storage import storage
+from telegram_auto_poster.utils.stats import stats
+from telegram_auto_poster.utils.storage import storage
 
 # Define error constants
 ERROR_MINIO_FILE_NOT_FOUND = "File not found in MinIO storage"

--- a/telegram_auto_poster/bot/permissions.py
+++ b/telegram_auto_poster/bot/permissions.py
@@ -2,7 +2,7 @@ from loguru import logger
 from telegram import Update
 from telegram.ext import ContextTypes
 
-from ..config import load_config
+from telegram_auto_poster.config import load_config
 
 
 async def check_admin_rights(

--- a/telegram_auto_poster/client/client.py
+++ b/telegram_auto_poster/client/client.py
@@ -4,8 +4,8 @@ import os
 from loguru import logger
 from telethon import TelegramClient, events, types
 
-from ..bot.handlers import process_photo, process_video
-from ..utils.stats import stats
+from telegram_auto_poster.bot.handlers import process_photo, process_video
+from telegram_auto_poster.utils.stats import stats
 
 # Create a global client variable that can be accessed from other modules
 client_instance = None

--- a/telegram_auto_poster/main.py
+++ b/telegram_auto_poster/main.py
@@ -2,12 +2,12 @@ import asyncio
 import signal
 from pathlib import Path
 
-from .bot.bot import TelegramMemeBot
-from .client.client import TelegramMemeClient
-from .config import load_config
-from .utils.logger_setup import setup_logger
-from .utils.stats import init_stats, stats
-from .utils.storage import init_storage
+from telegram_auto_poster.bot.bot import TelegramMemeBot
+from telegram_auto_poster.client.client import TelegramMemeClient
+from telegram_auto_poster.config import load_config
+from telegram_auto_poster.utils.logger_setup import setup_logger
+from telegram_auto_poster.utils.stats import init_stats, stats
+from telegram_auto_poster.utils.storage import init_storage
 
 # Setup logger
 logger = setup_logger()

--- a/telegram_auto_poster/media/photo.py
+++ b/telegram_auto_poster/media/photo.py
@@ -10,7 +10,7 @@ from PIL.ImageFile import ImageFile
 from telegram_auto_poster.utils import MinioError
 from telegram_auto_poster.utils.storage import storage
 
-from ..config import BUCKET_MAIN, PHOTOS_PATH
+from telegram_auto_poster.config import BUCKET_MAIN, PHOTOS_PATH
 
 
 async def add_watermark_to_image(

--- a/telegram_auto_poster/media/video.py
+++ b/telegram_auto_poster/media/video.py
@@ -10,7 +10,7 @@ from loguru import logger
 from telegram_auto_poster.utils import MinioError
 from telegram_auto_poster.utils.storage import storage
 
-from ..config import BUCKET_MAIN, VIDEOS_PATH
+from telegram_auto_poster.config import BUCKET_MAIN, VIDEOS_PATH
 
 
 async def _probe_video_size(path: str) -> tuple[int, int]:

--- a/telegram_auto_poster/utils/deduplication.py
+++ b/telegram_auto_poster/utils/deduplication.py
@@ -4,7 +4,7 @@ import imagehash
 from loguru import logger
 from PIL import Image
 
-from .db import get_redis_client
+from telegram_auto_poster.utils.db import get_redis_client
 
 DEDUPLICATION_SET_KEY = (
     "telegram_auto_poster:media_hashes"  # Stores hashes of APPROVED media

--- a/telegram_auto_poster/utils/stats.py
+++ b/telegram_auto_poster/utils/stats.py
@@ -17,7 +17,11 @@ from sqlalchemy.orm import declarative_base, sessionmaker
 
 from telegram_auto_poster.utils.timezone import UTC, now_utc
 
-from .db import _redis_key, _redis_meta_key, get_redis_client
+from telegram_auto_poster.utils.db import (
+    _redis_key,
+    _redis_meta_key,
+    get_redis_client,
+)
 
 Base = declarative_base()
 


### PR DESCRIPTION
## Summary
- replace relative package imports with absolute ones
- ensure modules reference `telegram_auto_poster` explicitly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689f2a55d014832e94f125f40efff5d0