### PR TITLE
Handle missing stats in Telethon client

### DIFF
--- a/telegram_auto_poster/client/client.py
+++ b/telegram_auto_poster/client/client.py
@@ -5,7 +5,7 @@ from loguru import logger
 from telethon import TelegramClient, events, types
 
 from telegram_auto_poster.bot.handlers import process_photo, process_video
-from telegram_auto_poster.utils.stats import stats
+from telegram_auto_poster.utils import stats as stats_module
 
 # Create a global client variable that can be accessed from other modules
 client_instance = None
@@ -72,7 +72,8 @@ class TelegramMemeClient:
                 if isinstance(event.media, types.MessageMediaPhoto):
                     photo = event.media.photo
                     file_path = f"downloaded_image_{event.id}.jpg"
-                    stats.record_received("photo")
+                    if stats_module.stats:
+                        stats_module.stats.record_received("photo")
                     await self.client.download_media(photo, file=file_path)
                     await process_photo(
                         "New post found with image",
@@ -86,7 +87,8 @@ class TelegramMemeClient:
                         logger.info(
                             f"Video with eventid {event.id} has started downloading!"
                         )
-                        stats.record_received("video")
+                        if stats_module.stats:
+                            stats_module.stats.record_received("video")
                         video = event.media.document
                         file_path = f"downloaded_video_{event.id}.mp4"
                         await self.client.download_media(video, file=file_path)


### PR DESCRIPTION
## Summary
- Guard against uninitialized stats in TelegramMemeClient by referencing the stats module and checking the instance before recording

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689f3a74266c832eb7c6341fef462a4a