### PR TITLE
Fix scheduled media job path handling

### DIFF
--- a/telegram_auto_poster/bot/commands.py
+++ b/telegram_auto_poster/bot/commands.py
@@ -13,7 +13,6 @@ from telegram_auto_poster.config import (
     BUCKET_MAIN,
     DOWNLOADS_PATH,
     PHOTOS_PATH,
-    SCHEDULED_PATH,
     VIDEOS_PATH,
 )
 from telegram_auto_poster.utils.general import (
@@ -391,9 +390,7 @@ async def post_scheduled_media_job(context: ContextTypes.DEFAULT_TYPE) -> None:
             temp_path = None
             try:
                 # Download from MinIO
-                temp_path, _ = await download_from_minio(
-                    SCHEDULED_PATH + "/" + file_path, BUCKET_MAIN
-                )
+                temp_path, _ = await download_from_minio(file_path, BUCKET_MAIN)
 
                 # Send to channel without caption, enabling streaming for videos
                 await send_media_to_telegram(
@@ -408,7 +405,7 @@ async def post_scheduled_media_job(context: ContextTypes.DEFAULT_TYPE) -> None:
                 )
 
                 # Clean up
-                storage.delete_file(SCHEDULED_PATH + "/" + file_path, BUCKET_MAIN)
+                storage.delete_file(file_path, BUCKET_MAIN)
                 db.remove_scheduled_post(file_path)
 
                 logger.info(f"Successfully posted scheduled media: {file_path}")


### PR DESCRIPTION
## Summary
- avoid double prefix when downloading/deleting scheduled media
- add regression test for scheduled media job

## Testing
- `uv run ruff format --check telegram_auto_poster/bot/commands.py test/test_commands.py`
- `uv run ruff check telegram_auto_poster/bot/commands.py test/test_commands.py`
- `uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a42cc91508832eac395e2555786922