### PR TITLE
Add scheduled post navigation with push option

### DIFF
--- a/telegram_auto_poster/bot/bot.py
+++ b/telegram_auto_poster/bot/bot.py
@@ -16,6 +16,7 @@ from telegram_auto_poster.bot.callbacks import (
     notok_callback,
     ok_callback,
     push_callback,
+    schedule_browser_callback,
     schedule_callback,
     unschedule_callback,
 )
@@ -132,6 +133,12 @@ class TelegramMemeBot:
         )
         self.application.add_handler(
             CallbackQueryHandler(unschedule_callback, pattern=r"^/unschedule:")
+        )
+        self.application.add_handler(
+            CallbackQueryHandler(
+                schedule_browser_callback,
+                pattern=r"^/sch_(prev|next|unschedule|push):",
+            )
         )
 
         # Register media handler

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -274,3 +274,53 @@ async def test_post_scheduled_media_job_uses_correct_path(
         scheduled_path, commands.BUCKET_MAIN
     )
     commands.db.remove_scheduled_post.assert_called_once_with(scheduled_path)
+
+
+@pytest.mark.asyncio
+async def test_sch_command_uses_preview(mocker: MockerFixture, commands):
+    update = SimpleNamespace(
+        effective_user=SimpleNamespace(id=1),
+        effective_chat=SimpleNamespace(id=99),
+        message=SimpleNamespace(reply_text=mocker.AsyncMock()),
+    )
+    context = SimpleNamespace(bot=SimpleNamespace())
+    mocker.patch.object(commands, "check_admin_rights", return_value=True)
+    mocker.patch.object(commands.db, "get_scheduled_posts", return_value=[("p1.jpg", 0)])
+    preview = mocker.patch.object(
+        commands, "send_schedule_preview", new=mocker.AsyncMock()
+    )
+
+    await commands.sch_command(update, context)
+
+    preview.assert_awaited_once_with(context.bot, 99, "p1.jpg", 0)
+
+
+@pytest.mark.asyncio
+async def test_send_schedule_preview_builds_markup(
+    tmp_path, mocker: MockerFixture
+):
+    from telegram_auto_poster.bot.callbacks import send_schedule_preview
+
+    temp_file = tmp_path / "t.jpg"
+    temp_file.write_bytes(b"data")
+
+    mocker.patch(
+        "telegram_auto_poster.bot.callbacks.download_from_minio",
+        return_value=(str(temp_file), None),
+    )
+    edit_mock = mocker.AsyncMock()
+    msg = SimpleNamespace(edit_reply_markup=edit_mock)
+    send_media = mocker.AsyncMock(return_value=msg)
+    mocker.patch(
+        "telegram_auto_poster.bot.callbacks.send_media_to_telegram", send_media
+    )
+
+    bot = SimpleNamespace()
+    await send_schedule_preview(bot, 1, "photos/a.jpg", 2)
+
+    send_media.assert_awaited_once()
+    assert edit_mock.awaited
+    markup = edit_mock.call_args.kwargs["reply_markup"]
+    texts = [b.text for b in markup.inline_keyboard[0]]
+    assert texts == ["Prev", "Unschedule", "Push", "Next"]
+    assert markup.inline_keyboard[0][3].callback_data == "/sch_next:2"


### PR DESCRIPTION
## Summary
- add scrollable preview for scheduled posts with buttons to navigate, push, or unschedule
- wire /sch command and new callback handler for interactive schedule browsing
- cover new functionality with tests

## Testing
- `uv run ruff format`
- `uv run ruff check --select I --fix`
- `uv run pytest -n auto`


------
https://chatgpt.com/codex/tasks/task_b_68a430f251ec832e8361ec9dfdfdc04a