### PR TITLE
Refactor schedule browser actions and add tests

### DIFF
--- a/telegram_auto_poster/bot/bot.py
+++ b/telegram_auto_poster/bot/bot.py
@@ -16,6 +16,7 @@ from telegram_auto_poster.bot.callbacks import (
     notok_callback,
     ok_callback,
     push_callback,
+    schedule_browser_callback,
     schedule_callback,
     unschedule_callback,
 )
@@ -132,6 +133,12 @@ class TelegramMemeBot:
         )
         self.application.add_handler(
             CallbackQueryHandler(unschedule_callback, pattern=r"^/unschedule:")
+        )
+        self.application.add_handler(
+            CallbackQueryHandler(
+                schedule_browser_callback,
+                pattern=r"^/sch_(prev|next|unschedule|push):",
+            )
         )
 
         # Register media handler

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -274,3 +274,56 @@ async def test_post_scheduled_media_job_uses_correct_path(
         scheduled_path, commands.BUCKET_MAIN
     )
     commands.db.remove_scheduled_post.assert_called_once_with(scheduled_path)
+
+
+@pytest.mark.asyncio
+async def test_sch_command_uses_preview(mocker: MockerFixture, commands):
+    update = SimpleNamespace(
+        effective_user=SimpleNamespace(id=1),
+        effective_chat=SimpleNamespace(id=99),
+        message=SimpleNamespace(reply_text=mocker.AsyncMock()),
+    )
+    context = SimpleNamespace(bot=SimpleNamespace())
+    mocker.patch.object(commands, "check_admin_rights", return_value=True)
+    mocker.patch.object(commands.db, "get_scheduled_posts", return_value=[("p1.jpg", 0)])
+    preview = mocker.patch.object(
+        commands, "send_schedule_preview", new=mocker.AsyncMock()
+    )
+
+    await commands.sch_command(update, context)
+
+    preview.assert_awaited_once_with(context.bot, 99, "p1.jpg", 0)
+
+
+@pytest.mark.asyncio
+async def test_send_schedule_preview_builds_markup(
+    tmp_path, mocker: MockerFixture
+):
+    from telegram_auto_poster.bot.callbacks import send_schedule_preview
+
+    temp_file = tmp_path / "t.jpg"
+    temp_file.write_bytes(b"data")
+
+    mocker.patch(
+        "telegram_auto_poster.bot.callbacks.download_from_minio",
+        return_value=(str(temp_file), None),
+    )
+    edit_mock = mocker.AsyncMock()
+    msg = SimpleNamespace(edit_reply_markup=edit_mock)
+    send_media = mocker.AsyncMock(return_value=msg)
+    mocker.patch(
+        "telegram_auto_poster.bot.callbacks.send_media_to_telegram", send_media
+    )
+
+    bot = SimpleNamespace()
+    await send_schedule_preview(bot, 1, "photos/a.jpg", 2)
+
+    send_media.assert_awaited_once()
+    assert edit_mock.awaited
+    markup = edit_mock.call_args.kwargs["reply_markup"]
+    texts = [b.text for b in markup.inline_keyboard[0]]
+    assert texts == ["Prev", "Unschedule", "Push", "Next"]
+    row = markup.inline_keyboard[0]
+    assert row[1].callback_data == "/sch_unschedule:2:photos/a.jpg"
+    assert row[2].callback_data == "/sch_push:2:photos/a.jpg"
+    assert row[3].callback_data == "/sch_next:2"

--- a/test/test_schedule_browser_callback.py
+++ b/test/test_schedule_browser_callback.py
@@ -1,0 +1,164 @@
+import pytest
+from types import SimpleNamespace
+from pytest_mock import MockerFixture
+
+from telegram_auto_poster.bot.callbacks import schedule_browser_callback
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "data,expected_path,expected_idx",
+    [
+        ("/sch_prev:0", "p3", 2),
+        ("/sch_next:2", "p1", 0),
+    ],
+)
+async def test_schedule_browser_navigation_wraps(
+    mocker: MockerFixture, data, expected_path, expected_idx
+):
+    scheduled = [("p1", 0), ("p2", 0), ("p3", 0)]
+    mocker.patch(
+        "telegram_auto_poster.bot.callbacks.db.get_scheduled_posts",
+        return_value=scheduled,
+    )
+    preview = mocker.patch(
+        "telegram_auto_poster.bot.callbacks.send_schedule_preview",
+        new=mocker.AsyncMock(),
+    )
+    message = SimpleNamespace(
+        chat_id=1, delete=mocker.AsyncMock(), edit_text=mocker.AsyncMock()
+    )
+    query = SimpleNamespace(
+        data=data,
+        message=message,
+        answer=mocker.AsyncMock(),
+        from_user=SimpleNamespace(id=1),
+    )
+    update = SimpleNamespace(callback_query=query)
+    context = SimpleNamespace(bot=SimpleNamespace())
+
+    await schedule_browser_callback(update, context)
+
+    preview.assert_awaited_once_with(context.bot, 1, expected_path, expected_idx)
+
+
+@pytest.mark.asyncio
+async def test_schedule_browser_unschedule_removes_and_shows_next(
+    mocker: MockerFixture,
+):
+    mocker.patch(
+        "telegram_auto_poster.bot.callbacks.db.get_scheduled_posts",
+        return_value=[("p1", 0), ("p3", 0)],
+    )
+    remove = mocker.patch(
+        "telegram_auto_poster.bot.callbacks.db.remove_scheduled_post"
+    )
+    exists = mocker.patch(
+        "telegram_auto_poster.bot.callbacks.storage.file_exists", return_value=True
+    )
+    delete = mocker.patch(
+        "telegram_auto_poster.bot.callbacks.storage.delete_file"
+    )
+    preview = mocker.patch(
+        "telegram_auto_poster.bot.callbacks.send_schedule_preview",
+        new=mocker.AsyncMock(),
+    )
+    message = SimpleNamespace(
+        chat_id=1, delete=mocker.AsyncMock(), edit_text=mocker.AsyncMock()
+    )
+    query = SimpleNamespace(
+        data="/sch_unschedule:1:p2",
+        message=message,
+        answer=mocker.AsyncMock(),
+        from_user=SimpleNamespace(id=1),
+    )
+    update = SimpleNamespace(callback_query=query)
+    context = SimpleNamespace(bot=SimpleNamespace())
+
+    await schedule_browser_callback(update, context)
+
+    remove.assert_called_once_with("p2")
+    exists.assert_called_once()
+    delete.assert_called_once()
+    preview.assert_awaited_once_with(context.bot, 1, "p3", 1)
+
+
+@pytest.mark.asyncio
+async def test_schedule_browser_push_sends_and_shows_next(mocker: MockerFixture):
+    mocker.patch(
+        "telegram_auto_poster.bot.callbacks.db.get_scheduled_posts",
+        return_value=[("p1.mp4", 0)],
+    )
+    mocker.patch(
+        "telegram_auto_poster.bot.callbacks.db.remove_scheduled_post"
+    )
+    mocker.patch(
+        "telegram_auto_poster.bot.callbacks.storage.file_exists", return_value=False
+    )
+    preview = mocker.patch(
+        "telegram_auto_poster.bot.callbacks.send_schedule_preview",
+        new=mocker.AsyncMock(),
+    )
+    download = mocker.patch(
+        "telegram_auto_poster.bot.callbacks.download_from_minio",
+        new=mocker.AsyncMock(return_value=("/tmp/t.mp4", None)),
+    )
+    send_media = mocker.patch(
+        "telegram_auto_poster.bot.callbacks.send_media_to_telegram",
+        new=mocker.AsyncMock(),
+    )
+    mocker.patch("telegram_auto_poster.bot.callbacks.cleanup_temp_file")
+
+    message = SimpleNamespace(
+        chat_id=1, delete=mocker.AsyncMock(), edit_text=mocker.AsyncMock()
+    )
+    query = SimpleNamespace(
+        data="/sch_push:0:p2.mp4",
+        message=message,
+        answer=mocker.AsyncMock(),
+        from_user=SimpleNamespace(id=1),
+    )
+    update = SimpleNamespace(callback_query=query)
+    context = SimpleNamespace(bot=SimpleNamespace(), bot_data={"target_channel_id": 99})
+
+    await schedule_browser_callback(update, context)
+
+    download.assert_awaited_once()
+    send_media.assert_awaited_once_with(
+        context.bot, 99, "/tmp/t.mp4", caption=None, supports_streaming=True
+    )
+    preview.assert_awaited_once_with(context.bot, 1, "p1.mp4", 0)
+
+
+@pytest.mark.asyncio
+async def test_schedule_browser_unschedule_last_shows_none(mocker: MockerFixture):
+    mocker.patch(
+        "telegram_auto_poster.bot.callbacks.db.get_scheduled_posts", return_value=[]
+    )
+    mocker.patch(
+        "telegram_auto_poster.bot.callbacks.db.remove_scheduled_post"
+    )
+    mocker.patch(
+        "telegram_auto_poster.bot.callbacks.storage.file_exists", return_value=False
+    )
+    mocker.patch("telegram_auto_poster.bot.callbacks.storage.delete_file")
+    preview = mocker.patch(
+        "telegram_auto_poster.bot.callbacks.send_schedule_preview",
+        new=mocker.AsyncMock(),
+    )
+    message = SimpleNamespace(
+        chat_id=1, delete=mocker.AsyncMock(), edit_text=mocker.AsyncMock()
+    )
+    query = SimpleNamespace(
+        data="/sch_unschedule:0:p1",
+        message=message,
+        answer=mocker.AsyncMock(),
+        from_user=SimpleNamespace(id=1),
+    )
+    update = SimpleNamespace(callback_query=query)
+    context = SimpleNamespace(bot=SimpleNamespace())
+
+    await schedule_browser_callback(update, context)
+
+    message.edit_text.assert_awaited_once_with("No posts scheduled.")
+    assert preview.await_count == 0


### PR DESCRIPTION
## Summary
- avoid repeating video streaming checks with a helper
- consolidate unschedule and push cleanup logic
- cover schedule browser navigation and actions with unit tests

## Testing
- `uv run ruff format`
- `uv run ruff check --select I --fix`
- `uv run pytest -n auto`


------
https://chatgpt.com/codex/tasks/task_b_68a430f251ec832e8361ec9dfdfdc04a