### PR TITLE
feat(web): add send batch button

### DIFF
--- a/telegram_auto_poster/web/templates/batch.html
+++ b/telegram_auto_poster/web/templates/batch.html
@@ -9,7 +9,7 @@
 {% if posts %}
 <form
     method="post"
-    action="/batch/send{{ key_query }}"
+    action="/batch/send"
     onsubmit="return confirm('Send whole batch?');"
 >
     <input type="hidden" name="key" value="{{ key }}" />


### PR DESCRIPTION
## Summary
- add `/batch/send` endpoint to push each batch item and track counts
- display prominent button on batch page for sending the whole batch

## Testing
- `uv run ruff check --select I --fix`
- `uv run ruff check`
- `uv run ruff format`
- `uv run pytest -n auto`


------
https://chatgpt.com/codex/tasks/task_b_68ac373e05e8832e91c6d524144590c2