### PR TITLE
feat(web): improve mobile responsiveness

### DIFF
--- a/telegram_auto_poster/web/templates/_batch_grid.html
+++ b/telegram_auto_poster/web/templates/_batch_grid.html
@@ -1,9 +1,9 @@
 {% if posts %}
 <div class="row g-3">
     {% for p in posts %}
-    <div class="col-md-4">
+    <div class="col-sm-6 col-md-4">
         {% if p.is_video %}
-        <video class="img-fluid" controls src="{{ p.url }}"></video>
+        <video class="img-fluid" controls playsinline src="{{ p.url }}"></video>
         {% elif p.is_image %}
         <img class="img-fluid" src="{{ p.url }}" alt="{{ alt_text }}" />
         {% endif %}

--- a/telegram_auto_poster/web/templates/_post_grid.html
+++ b/telegram_auto_poster/web/templates/_post_grid.html
@@ -1,9 +1,9 @@
 {% if posts %}
 <div class="row g-3">
     {% for p in posts %}
-    <div class="col-md-4">
+    <div class="col-sm-6 col-md-4">
         {% if p.is_video %}
-        <video class="img-fluid" controls src="{{ p.url }}"></video>
+        <video class="img-fluid" controls playsinline src="{{ p.url }}"></video>
         {% elif p.is_image %}
         <img class="img-fluid" src="{{ p.url }}" alt="{{ alt_text }}" />
         {% endif %}

--- a/telegram_auto_poster/web/templates/base.html
+++ b/telegram_auto_poster/web/templates/base.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Telegram Autoposter Admin</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="icon" type="image/x-icon" href="/static/favicon.ico">

--- a/telegram_auto_poster/web/templates/queue.html
+++ b/telegram_auto_poster/web/templates/queue.html
@@ -39,12 +39,12 @@
                     </div>
                     <div class="collapse mt-2" id="preview-{{ loop.index0 }}">
                         {% if p.is_video %}
-                            <video class="queue-video" controls preload="none" playsinline style="max-width: 220px; max-height: 180px;">
+                            <video class="queue-video img-fluid" controls preload="none" playsinline style="max-height: 180px;">
                                 <source src="{{ p.url }}" {% if p.mime %}type="{{ p.mime }}"{% endif %} />
                                 Your browser does not support the video tag.
                             </video>
                         {% elif p.is_image %}
-                            <img src="{{ p.url }}" loading="lazy" class="img-fluid" style="max-width: 220px; max-height: 180px; object-fit: contain;" alt="preview">
+                            <img src="{{ p.url }}" loading="lazy" class="img-fluid" style="max-height: 180px; object-fit: contain;" alt="preview">
                         {% else %}
                             <a href="{{ p.url }}" target="_blank" rel="noopener noreferrer">Open</a>
                         {% endif %}


### PR DESCRIPTION
## Summary
- add viewport meta tag for proper mobile scaling
- use responsive columns and inline video playback in post/batch grids
- make queue previews fluid for small screens

## Testing
- `uv run ruff check --select I --fix`
- `uv run ruff check`
- `uv run ruff format`
- `uv run pytest -n auto`


------
https://chatgpt.com/codex/tasks/task_b_68ad4b461ad8832eba6b09f18f92bbbb