### PR TITLE
Display channel posts count on dashboard

### DIFF
--- a/telegram_auto_poster/web/app.py
+++ b/telegram_auto_poster/web/app.py
@@ -159,6 +159,28 @@ async def _get_suggestions_count() -> int:
     return count
 
 
+async def _get_posts_count() -> int:
+    objects: list[str] = []
+    objects += await storage.list_files(BUCKET_MAIN, prefix=f"{PHOTOS_PATH}/processed_")
+    objects += await storage.list_files(BUCKET_MAIN, prefix=f"{VIDEOS_PATH}/processed_")
+
+    tasks = [storage.get_submission_metadata(os.path.basename(obj)) for obj in objects]
+    results = await asyncio.gather(*tasks)
+
+    count = 0
+    groups: set[str] = set()
+    for meta in results:
+        if meta and meta.get("user_id"):
+            continue
+        group_id = meta.get("group_id") if meta else None
+        if group_id:
+            groups.add(group_id)
+        else:
+            count += 1
+
+    return count + len(groups)
+
+
 async def _render_posts_page(
     request: Request,
     *,
@@ -186,9 +208,16 @@ async def _render_posts_page(
 
 @app.get("/", response_class=HTMLResponse, dependencies=[Depends(require_access_key)])
 async def index(request: Request) -> HTMLResponse:
-    suggestions_count, batch_count, scheduled_posts_raw, daily = await asyncio.gather(
+    (
+        suggestions_count,
+        batch_count,
+        posts_count,
+        scheduled_posts_raw,
+        daily,
+    ) = await asyncio.gather(
         _get_suggestions_count(),
         _get_batch_count(),
+        _get_posts_count(),
         run_in_threadpool(get_scheduled_posts),
         stats.get_daily_stats(reset_if_new_day=False),
     )
@@ -196,6 +225,7 @@ async def index(request: Request) -> HTMLResponse:
         "request": request,
         "suggestions_count": suggestions_count,
         "batch_count": batch_count,
+        "posts_count": posts_count,
         "scheduled_count": len(scheduled_posts_raw),
         "daily": daily,
     }

--- a/telegram_auto_poster/web/templates/index.html
+++ b/telegram_auto_poster/web/templates/index.html
@@ -10,7 +10,7 @@
 </div>
 
 <div class="row">
-    <div class="col-md-4">
+    <div class="col-md-3">
         <div class="card text-center mb-3">
             <div class="card-body">
                 <h5 class="card-title">Pending Suggestions</h5>
@@ -19,7 +19,7 @@
             </div>
         </div>
     </div>
-    <div class="col-md-4">
+    <div class="col-md-3">
         <div class="card text-center mb-3">
             <div class="card-body">
                 <h5 class="card-title">Items in Batch</h5>
@@ -28,12 +28,21 @@
             </div>
         </div>
     </div>
-    <div class="col-md-4">
+    <div class="col-md-3">
         <div class="card text-center mb-3">
             <div class="card-body">
                 <h5 class="card-title">Scheduled Posts</h5>
                 <p class="card-text fs-1">{{ scheduled_count }}</p>
                 <a href="/queue{{ key_query }}" class="btn btn-primary">View Queue</a>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3">
+        <div class="card text-center mb-3">
+            <div class="card-body">
+                <h5 class="card-title">Channel Posts</h5>
+                <p class="card-text fs-1">{{ posts_count }}</p>
+                <a href="/posts{{ key_query }}" class="btn btn-primary">View Posts</a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- show total channel posts on the admin home page
- compute post count excluding suggestions and grouped items

## Testing
- `uv run ruff check --select I --fix`
- `uv run ruff check`
- `uv run ruff format`
- `uv run pytest -n auto`


------
https://chatgpt.com/codex/tasks/task_b_68ad899a9308832ea923d03cb8e790de