### PR TITLE
Test web dashboard with FastAPI TestClient and expand coverage

### DIFF
--- a/test/utils/test_client_resilience.py
+++ b/test/utils/test_client_resilience.py
@@ -8,8 +8,20 @@ def test_backoff_delay_cap():
     assert delays[-1] == 5
 
 
+def test_backoff_delay_jitter():
+    delay = backoff_delay(2, base=1, cap=5, jitter=0.1)
+    assert 1.8 <= delay <= 2.2
+
+
 @pytest.mark.asyncio
 async def test_rate_limiter_drop():
     limiter = RateLimiter(rate=1, capacity=1)
     assert await limiter.acquire(drop=True)
     assert not await limiter.acquire(drop=True)
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_wait_for_token():
+    limiter = RateLimiter(rate=1000, capacity=1)
+    assert await limiter.acquire()
+    assert await limiter.acquire()

--- a/test/utils/test_db.py
+++ b/test/utils/test_db.py
@@ -1,34 +1,21 @@
+import fakeredis
 import pytest
+import pytest_asyncio
+from telegram_auto_poster.config import CONFIG
 from telegram_auto_poster.utils import db
 
 
-class FakeRedis:
-    def __init__(self):
-        self.store: dict[str, int] = {}
-
-    async def incrby(self, key, amount):
-        self.store[key] = int(self.store.get(key, 0)) + amount
-        return self.store[key]
-
-    async def decrby(self, key, amount):
-        self.store[key] = int(self.store.get(key, 0)) - amount
-        return self.store[key]
-
-    async def get(self, key):
-        value = self.store.get(key)
-        return str(value) if value is not None else None
-
-    async def set(self, key, value):
-        self.store[key] = int(value)
-
-
-@pytest.fixture
-def mock_async_redis(mocker):
-    client = FakeRedis()
+@pytest_asyncio.fixture
+async def mock_async_redis(mocker):
     mocker.patch(
-        "telegram_auto_poster.utils.db.get_async_redis_client", return_value=client
+        "telegram_auto_poster.utils.db.AsyncValkey", fakeredis.aioredis.FakeRedis
     )
-    return client
+    mocker.patch.object(CONFIG.valkey.password, "get_secret_value", return_value=None)
+    db._async_redis_client = None
+    client = db.get_async_redis_client()
+    await client.flushdb()
+    yield client
+    await client.flushdb()
 
 
 @pytest.mark.asyncio
@@ -38,3 +25,37 @@ async def test_batch_counter(mock_async_redis):
     assert await db.increment_batch_count(2) == 3
     assert await db.decrement_batch_count(1) == 2
     assert await db.get_batch_count() == 2
+
+
+@pytest.mark.asyncio
+async def test_decrement_batch_clamped_to_zero(mock_async_redis):
+    assert await db.get_batch_count() == 0
+    assert await db.decrement_batch_count(5) == 0
+
+
+def test_get_redis_client_flushes_between_calls(mocker):
+    mocker.patch("telegram_auto_poster.utils.db.Valkey", fakeredis.FakeRedis)
+    mocker.patch.object(CONFIG.valkey.password, "get_secret_value", return_value=None)
+    db._redis_client = None
+    client = db.get_redis_client()
+    client.set("foo", "1")
+    client = db.get_redis_client()
+    assert client.get("foo") is None
+
+
+def test_get_redis_client_imports_valkey(mocker):
+    mocker.patch("valkey.Valkey", fakeredis.FakeRedis)
+    mocker.patch.object(CONFIG.valkey.password, "get_secret_value", return_value=None)
+    db._redis_client = None
+    mocker.patch.object(db, "Valkey", None)
+    client = db.get_redis_client()
+    assert isinstance(client, fakeredis.FakeRedis)
+
+
+def test_schedule_roundtrip(mocker):
+    fake = fakeredis.FakeRedis(decode_responses=True)
+    mocker.patch("telegram_auto_poster.utils.db.get_redis_client", return_value=fake)
+    db.add_scheduled_post(100, "foo")
+    assert db.get_scheduled_posts() == [("foo", 100.0)]
+    db.remove_scheduled_post("foo")
+    assert db.get_scheduled_posts() == []

--- a/test/utils/test_general.py
+++ b/test/utils/test_general.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 from telegram_auto_poster.utils.general import (
     cleanup_temp_file,
@@ -30,6 +32,7 @@ def test_extract_filename(text, expected):
         ("", []),
         ("photos/a.jpg\nphotos/b.jpg", ["photos/a.jpg", "photos/b.jpg"]),
         ("videos/a.mp4", ["videos/a.mp4"]),
+        ("   ", []),
     ],
 )
 def test_extract_file_paths(text, expected):
@@ -52,6 +55,18 @@ def test_cleanup_temp_file_non_existent_file(tmp_path):
     # Should not raise when file does not exist
     non_existent_file = tmp_path / "non_existent_file.txt"
     cleanup_temp_file(str(non_existent_file))
+
+
+def test_cleanup_temp_file_logs_error(tmp_path, monkeypatch):
+    temp_file = tmp_path / "temp.txt"
+    temp_file.write_text("data")
+
+    def boom(path):  # pragma: no cover - raises intentionally
+        raise OSError("fail")
+
+    monkeypatch.setattr(os, "unlink", boom)
+    cleanup_temp_file(str(temp_file))
+    assert temp_file.exists()
 
 
 @pytest.mark.parametrize(

--- a/test/utils/test_stats.py
+++ b/test/utils/test_stats.py
@@ -1,0 +1,48 @@
+import fakeredis
+import pytest
+import pytest_asyncio
+
+from telegram_auto_poster.config import CONFIG
+from telegram_auto_poster.utils import db
+from telegram_auto_poster.utils.stats import MediaStats
+from telegram_auto_poster.utils.db import _redis_key
+
+
+@pytest_asyncio.fixture
+async def stats_instance(mocker):
+    mocker.patch("telegram_auto_poster.utils.db.AsyncValkey", fakeredis.aioredis.FakeRedis)
+    mocker.patch.object(CONFIG.valkey.password, "get_secret_value", return_value=None)
+    db._async_redis_client = None
+    MediaStats._instance = None
+    inst = MediaStats()
+    await inst.r.flushdb()
+    yield inst
+    await inst.r.flushdb()
+    MediaStats._instance = None
+
+
+@pytest.mark.asyncio
+async def test_rates(stats_instance):
+    daily = {
+        "photos_processed": 5,
+        "videos_processed": 5,
+        "photos_approved": 3,
+        "videos_approved": 2,
+        "media_received": 10,
+        "processing_errors": 1,
+        "storage_errors": 1,
+        "telegram_errors": 0,
+    }
+    assert await stats_instance.get_success_rate_24h(daily) == pytest.approx(80.0)
+
+    await stats_instance._increment("photos_processed", scope="total", count=10)
+    await stats_instance._increment("photos_approved", scope="total", count=7)
+    await stats_instance._increment("videos_approved", scope="total", count=1)
+    assert await stats_instance.get_approval_rate_total() == pytest.approx(80.0)
+
+
+@pytest.mark.asyncio
+async def test_get_busiest_hour(stats_instance):
+    await stats_instance.r.set(_redis_key("hourly", "2"), 3)
+    await stats_instance.r.set(_redis_key("hourly", "5"), 7)
+    assert await stats_instance.get_busiest_hour() == (5, 7)

--- a/test/utils/test_timezone.py
+++ b/test/utils/test_timezone.py
@@ -1,0 +1,20 @@
+import datetime
+
+from telegram_auto_poster.utils import timezone
+
+
+def test_now_utc_is_timezone_aware():
+    now = timezone.now_utc()
+    assert now.tzinfo is timezone.UTC
+
+
+def test_to_display_converts_naive():
+    naive = datetime.datetime(2024, 1, 1, 12, 0)
+    converted = timezone.to_display(naive)
+    assert converted.tzinfo == timezone.DISPLAY_TZ
+    assert converted.hour == 15
+
+
+def test_format_display_uses_display_tz():
+    dt = datetime.datetime(2024, 1, 1, 12, 0, tzinfo=datetime.timezone.utc)
+    assert timezone.format_display(dt, "%H:%M") == "15:00"

--- a/test/web/test_web_app.py
+++ b/test/web/test_web_app.py
@@ -1,0 +1,121 @@
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import SecretStr
+from telegram_auto_poster.web.app import CONFIG, app
+
+
+@pytest.fixture(autouse=True)
+def clear_access_key():
+    original = CONFIG.web.access_key
+    CONFIG.web.access_key = None
+    yield
+    CONFIG.web.access_key = original
+
+
+def test_queue_requires_access_key(mocker):
+    mocker.patch(
+        "telegram_auto_poster.web.app.run_in_threadpool",
+        new=mocker.AsyncMock(return_value=[]),
+    )
+    CONFIG.web.access_key = SecretStr("token")
+    with TestClient(app) as client:
+        resp = client.get("/queue")
+        assert resp.status_code == 401
+        resp = client.get("/queue?key=token")
+        assert resp.status_code == 200
+
+
+def test_queue_rejects_wrong_key(mocker):
+    mocker.patch(
+        "telegram_auto_poster.web.app.run_in_threadpool",
+        new=mocker.AsyncMock(return_value=[]),
+    )
+    CONFIG.web.access_key = SecretStr("token")
+    with TestClient(app) as client:
+        resp = client.get("/queue?key=bad")
+        assert resp.status_code == 401
+
+
+def test_queue_lists_posts(mocker):
+    mocker.patch(
+        "telegram_auto_poster.web.app.run_in_threadpool",
+        new=mocker.AsyncMock(return_value=[("photos/processed.jpg", 1)]),
+    )
+    mocker.patch(
+        "telegram_auto_poster.web.app.storage.get_presigned_url",
+        new=mocker.AsyncMock(return_value="http://example.com/photos/processed.jpg"),
+    )
+    CONFIG.web.access_key = SecretStr("token")
+    with TestClient(app) as client:
+        resp = client.get("/queue?key=token")
+        assert resp.status_code == 200
+        assert "http://example.com/photos/processed.jpg" in resp.text
+
+
+def test_stats_endpoint(mocker):
+    mocker.patch(
+        "telegram_auto_poster.web.app.stats.get_daily_stats",
+        new=mocker.AsyncMock(
+            return_value={
+                "processing_errors": 0,
+                "storage_errors": 0,
+                "telegram_errors": 0,
+            }
+        ),
+    )
+    mocker.patch(
+        "telegram_auto_poster.web.app.stats.get_total_stats",
+        new=mocker.AsyncMock(
+            return_value={
+                "processing_errors": 0,
+                "storage_errors": 0,
+                "telegram_errors": 0,
+            }
+        ),
+    )
+    mocker.patch(
+        "telegram_auto_poster.web.app.stats.get_performance_metrics",
+        new=mocker.AsyncMock(
+            return_value=SimpleNamespace(
+                avg_photo_processing_time=0,
+                avg_video_processing_time=0,
+                avg_upload_time=0,
+                avg_download_time=0,
+            )
+        ),
+    )
+    mocker.patch(
+        "telegram_auto_poster.web.app.stats.get_busiest_hour",
+        new=mocker.AsyncMock(return_value=(0, 0)),
+    )
+    mocker.patch(
+        "telegram_auto_poster.web.app.stats.get_approval_rate_24h",
+        new=mocker.AsyncMock(return_value=0.0),
+    )
+    mocker.patch(
+        "telegram_auto_poster.web.app.stats.get_approval_rate_total",
+        new=mocker.AsyncMock(return_value=0.0),
+    )
+    mocker.patch(
+        "telegram_auto_poster.web.app.stats.get_success_rate_24h",
+        new=mocker.AsyncMock(return_value=0.0),
+    )
+    CONFIG.web.access_key = SecretStr("token")
+    with TestClient(app) as client:
+        resp = client.get("/stats?key=token")
+        assert resp.status_code == 200
+
+
+def test_stats_requires_access_key():
+    CONFIG.web.access_key = SecretStr("token")
+    with TestClient(app) as client:
+        resp = client.get("/stats")
+        assert resp.status_code == 401
+
+def test_stats_rejects_wrong_key():
+    CONFIG.web.access_key = SecretStr("token")
+    with TestClient(app) as client:
+        resp = client.get("/stats?key=bad")
+        assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- add TestClient-powered tests for queue and stats FastAPI endpoints
- cover Redis helpers by testing flush behavior, Valkey import path, and scheduled post roundtrip
- switch DB tests to fakeredis-based clients to avoid external auth
- employ AsyncMock and context-managed TestClient in dashboard tests
- exercise MediaStats calculations and busiest-hour lookup with fakeredis
- test timezone utilities and ensure stats endpoint rejects invalid access keys
- broaden general utility coverage for file path extraction, temporary file cleanup failures, jittered backoff, and token wait in RateLimiter

## Testing
- `uv run ruff check --select I --fix test/utils/test_general.py test/utils/test_client_resilience.py`
- `uv run ruff check test/utils/test_general.py test/utils/test_client_resilience.py`
- `uv run ruff format test/utils/test_general.py test/utils/test_client_resilience.py`
- `uv run pytest -n auto`
- `uv run pytest --cov=telegram_auto_poster --cov-report=term-missing -q`


------
https://chatgpt.com/codex/tasks/task_b_68aedd6f8998832ea51df0c65cf992df