### PR TITLE
fix: require access key for action and unschedule endpoints

### DIFF
--- a/telegram_auto_poster/web/app.py
+++ b/telegram_auto_poster/web/app.py
@@ -303,7 +303,7 @@ async def send_batch(key: str | None = Form(None)) -> Response:
     return RedirectResponse(url=f"/batch{suffix}", status_code=303)
 
 
-@app.post("/action")
+@app.post("/action", dependencies=[Depends(require_access_key)])
 async def handle_action(
     request: Request,
     path: str | None = Form(None),
@@ -543,7 +543,7 @@ async def queue(request: Request) -> HTMLResponse:
     return templates.TemplateResponse("queue.html", context)
 
 
-@app.post("/queue/unschedule")
+@app.post("/queue/unschedule", dependencies=[Depends(require_access_key)])
 async def unschedule(
     request: Request, path: str = Form(...), key: str | None = Form(None)
 ) -> Response:


### PR DESCRIPTION
## Summary
- enforce access-key authentication on `/action` and `/queue/unschedule`
- extend web view tests to verify unauthorized requests are rejected

## Testing
- `uv run ruff check --select I --fix`
- `uv run ruff check`
- `uv run ruff format`
- `uv run pytest -n auto`


------
https://chatgpt.com/codex/tasks/task_b_68b1b8879bc4832e96c2d7c060d8084f