### PR TITLE
Cache admin config for permission checks

### DIFF
--- a/telegram_auto_poster/bot/permissions.py
+++ b/telegram_auto_poster/bot/permissions.py
@@ -23,29 +23,25 @@ async def check_admin_rights(
         user_id = update.effective_user.id
 
         admin_ids = None
-
         if hasattr(context, "bot_data"):
             admin_ids = context.bot_data.get("admin_ids")
 
-            if admin_ids is None:
+        if admin_ids is None:
+            config = None
+            if hasattr(context, "bot_data"):
                 config = context.bot_data.get("config")
 
-                if config is None:
-                    config = load_config()
+            if config is None:
+                config = load_config()
+                if hasattr(context, "bot_data"):
                     context.bot_data["config"] = config
 
-                admin_ids = list(config.bot.admin_ids or [])
-
-                if not admin_ids and getattr(config.bot, "bot_chat_id", None):
-                    admin_ids = [config.bot.bot_chat_id]
-
-                context.bot_data["admin_ids"] = admin_ids
-
-        else:
-            config = load_config()
             admin_ids = list(config.bot.admin_ids or [])
             if not admin_ids and getattr(config.bot, "bot_chat_id", None):
                 admin_ids = [config.bot.bot_chat_id]
+
+            if hasattr(context, "bot_data"):
+                context.bot_data["admin_ids"] = admin_ids
 
         if user_id in admin_ids:
             logger.debug(f"User {user_id} has admin rights")


### PR DESCRIPTION
## Summary
- refactor admin ID caching to avoid duplicate config loading logic

## Testing
- `uv run ruff check --select I --fix`
- `uv run ruff check`
- `uv run ruff format telegram_auto_poster/bot/permissions.py`
- `uv run pytest -n auto`


------
https://chatgpt.com/codex/tasks/task_b_68b7f9df065c832eb555f07807eb3944