### PR TITLE
Store submission metadata exclusively in Valkey

### DIFF
--- a/test/utils/test_storage.py
+++ b/test/utils/test_storage.py
@@ -3,7 +3,6 @@ from miniopy_async.error import MinioException
 from pytest_mock import MockerFixture
 from telegram_auto_poster.config import BUCKET_MAIN, PHOTOS_PATH
 from telegram_auto_poster.utils.db import _redis_key
-from telegram_auto_poster.utils.storage import MinioStorage
 
 
 @pytest.fixture
@@ -50,34 +49,47 @@ def patch_redis_client(mocker: MockerFixture, mock_redis_client: FakeRedis):
     )
 
 
-def test_init_storage(mock_minio_client):
+@pytest.fixture
+def storage_factory(mock_minio_client):
+    """Factory to create a clean MinioStorage instance."""
+
+    def _create():
+        from telegram_auto_poster.utils.storage import MinioStorage as StorageClass
+
+        StorageClass._instance = None
+        StorageClass._initialized = False
+        return StorageClass(client=mock_minio_client)
+
+    return _create
+
+
+@pytest.fixture
+def storage(storage_factory):
+    """Provides a MinioStorage instance for each test."""
+    storage_instance = storage_factory()
+    yield storage_instance
+    from telegram_auto_poster.utils.storage import MinioStorage as StorageClass
+
+    StorageClass._instance = None
+    StorageClass._initialized = False
+
+
+def test_init_storage(storage, mock_minio_client):
     """Test that the Minio client is initialized and buckets are checked."""
-    mock_minio_client.bucket_exists.return_value = True
-    storage = MinioStorage(client=mock_minio_client)
-    storage._instance = None
-    storage._initialized = False
-    storage = MinioStorage(client=mock_minio_client)
     mock_minio_client.bucket_exists.assert_called_once_with(BUCKET_MAIN)
     assert storage.client == mock_minio_client
 
 
-def test_init_storage_bucket_creation(mock_minio_client):
+def test_init_storage_bucket_creation(mock_minio_client, storage_factory):
     """Test that a bucket is created if it doesn't exist."""
     mock_minio_client.bucket_exists.return_value = False
-    storage = MinioStorage(client=mock_minio_client)
-    storage._instance = None
-    storage._initialized = False
-    storage = MinioStorage(client=mock_minio_client)
+    storage_factory()
     mock_minio_client.make_bucket.assert_called_once_with(BUCKET_MAIN)
 
 
 @pytest.mark.asyncio
-async def test_store_and_get_submission_metadata(mock_minio_client):
+async def test_store_and_get_submission_metadata(storage):
     """Test storing and retrieving submission metadata."""
-    storage = MinioStorage(client=mock_minio_client)
-    storage._instance = None
-    storage._initialized = False
-    storage = MinioStorage(client=mock_minio_client)
     await storage.store_submission_metadata(
         "obj1", 123, 456, "photo", message_id=789, media_hash="hash1", group_id="g1"
     )
@@ -88,12 +100,19 @@ async def test_store_and_get_submission_metadata(mock_minio_client):
 
 
 @pytest.mark.asyncio
-async def test_get_submission_metadata_from_redis(mock_minio_client, mock_redis_client):
+async def test_get_submission_metadata_normalizes_prefix(storage):
+    """Return metadata when only the basename is provided."""
+    object_name = f"{PHOTOS_PATH}/obj3"
+    await storage.store_submission_metadata(object_name, 1, 2, "photo")
+    meta = await storage.get_submission_metadata("obj3")
+    assert meta is not None
+
+
+@pytest.mark.asyncio
+async def test_get_submission_metadata_from_redis(
+    storage, mock_minio_client, mock_redis_client
+):
     """Metadata is retrieved from Redis when not in memory."""
-    storage = MinioStorage(client=mock_minio_client)
-    storage._instance = None
-    storage._initialized = False
-    storage = MinioStorage(client=mock_minio_client)
     await storage.store_submission_metadata(
         "obj_redis",
         111,
@@ -113,12 +132,8 @@ async def test_get_submission_metadata_from_redis(mock_minio_client, mock_redis_
 
 
 @pytest.mark.asyncio
-async def test_get_submission_metadata_missing(mock_minio_client):
+async def test_get_submission_metadata_missing(storage, mock_minio_client):
     """Return ``None`` when metadata is absent in memory and Valkey."""
-    storage = MinioStorage(client=mock_minio_client)
-    storage._instance = None
-    storage._initialized = False
-    storage = MinioStorage(client=mock_minio_client)
     storage.submission_metadata = {}
     meta = await storage.get_submission_metadata("obj2")
     assert meta is None
@@ -126,12 +141,8 @@ async def test_get_submission_metadata_missing(mock_minio_client):
 
 
 @pytest.mark.asyncio
-async def test_mark_notified(mock_minio_client, mock_redis_client):
+async def test_mark_notified(storage, mock_redis_client):
     """Test marking a submission as notified."""
-    storage = MinioStorage(client=mock_minio_client)
-    storage._instance = None
-    storage._initialized = False
-    storage = MinioStorage(client=mock_minio_client)
     await storage.store_submission_metadata("obj1", 123, 456, "photo")
     meta = await storage.get_submission_metadata("obj1")
     assert meta["notified"] is False
@@ -143,14 +154,10 @@ async def test_mark_notified(mock_minio_client, mock_redis_client):
 
 
 @pytest.mark.asyncio
-async def test_upload_file(mock_minio_client, tmp_path):
+async def test_upload_file(storage, mock_minio_client, tmp_path):
     """Test uploading a file."""
     file = tmp_path / "test.jpg"
     file.write_text("content")
-    storage = MinioStorage(client=mock_minio_client)
-    storage._instance = None
-    storage._initialized = False
-    storage = MinioStorage(client=mock_minio_client)
     await storage.upload_file(str(file), user_id=123, chat_id=456, group_id="g3")
     mock_minio_client.fput_object.assert_awaited_once()
     kwargs = mock_minio_client.fput_object.await_args.kwargs
@@ -163,13 +170,9 @@ async def test_upload_file(mock_minio_client, tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_download_file(mock_minio_client, tmp_path):
+async def test_download_file(storage, mock_minio_client, tmp_path):
     """Test downloading a file."""
     file = tmp_path / "download.jpg"
-    storage = MinioStorage(client=mock_minio_client)
-    storage._instance = None
-    storage._initialized = False
-    storage = MinioStorage(client=mock_minio_client)
     await storage.download_file("obj1", BUCKET_MAIN, file_path=str(file))
     mock_minio_client.fget_object.assert_awaited_once_with(
         bucket_name=BUCKET_MAIN, object_name="obj1", file_path=str(file)
@@ -177,17 +180,13 @@ async def test_download_file(mock_minio_client, tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_get_object_data(mock_minio_client, mocker: MockerFixture):
+async def test_get_object_data(storage, mock_minio_client, mocker: MockerFixture):
     """Test getting object data."""
     mock_response = mocker.MagicMock()
     mock_response.read = mocker.AsyncMock(return_value=b"data")
     mock_response.close = mocker.AsyncMock()
     mock_response.release_conn = mocker.AsyncMock()
     mock_minio_client.get_object.return_value = mock_response
-    storage = MinioStorage(client=mock_minio_client)
-    storage._instance = None
-    storage._initialized = False
-    storage = MinioStorage(client=mock_minio_client)
     data = await storage.get_object_data("obj1", BUCKET_MAIN)
     assert data == b"data"
     mock_response.close.assert_awaited_once()
@@ -195,24 +194,16 @@ async def test_get_object_data(mock_minio_client, mocker: MockerFixture):
 
 
 @pytest.mark.asyncio
-async def test_get_object_data_minio_error(mock_minio_client):
+async def test_get_object_data_minio_error(storage, mock_minio_client):
     """Test MinioException is raised when getting object data fails."""
     mock_minio_client.get_object.side_effect = MinioException("Failed to get object")
-    storage = MinioStorage(client=mock_minio_client)
-    storage._instance = None
-    storage._initialized = False
-    storage = MinioStorage(client=mock_minio_client)
     with pytest.raises(MinioException):
         await storage.get_object_data("obj1", BUCKET_MAIN)
 
 
 @pytest.mark.asyncio
-async def test_delete_file(mock_minio_client):
+async def test_delete_file(storage, mock_minio_client):
     """Test deleting a file."""
-    storage = MinioStorage(client=mock_minio_client)
-    storage._instance = None
-    storage._initialized = False
-    storage = MinioStorage(client=mock_minio_client)
     await storage.delete_file("obj1", BUCKET_MAIN)
     mock_minio_client.remove_object.assert_awaited_once_with(
         bucket_name=BUCKET_MAIN, object_name="obj1"
@@ -220,12 +211,8 @@ async def test_delete_file(mock_minio_client):
 
 
 @pytest.mark.asyncio
-async def test_file_exists(mock_minio_client):
+async def test_file_exists(storage, mock_minio_client):
     """Test checking if a file exists."""
-    storage = MinioStorage(client=mock_minio_client)
-    storage._instance = None
-    storage._initialized = False
-    storage = MinioStorage(client=mock_minio_client)
     await storage.file_exists("obj1", BUCKET_MAIN)
     mock_minio_client.stat_object.assert_awaited_once_with(
         bucket_name=BUCKET_MAIN, object_name="obj1"


### PR DESCRIPTION
## Summary
- Normalize object names when retrieving submission metadata to handle basename lookups
- Deduplicate MinioStorage test setup with reusable fixture and add test for basename lookup

## Testing
- `uv run ruff check --select I --fix telegram_auto_poster/utils/storage.py test/utils/test_storage.py`
- `uv run ruff check telegram_auto_poster/utils/storage.py test/utils/test_storage.py`
- `uv run ruff format telegram_auto_poster/utils/storage.py test/utils/test_storage.py`
- `uv run pytest -n auto`


------
https://chatgpt.com/codex/tasks/task_b_68b7f9ff0cf4832e8d7c99fa9219fd5d