### PR TITLE
feat(webdash): log-scale performance chart

### DIFF
--- a/telegram_auto_poster/web/static/js/charts.js
+++ b/telegram_auto_poster/web/static/js/charts.js
@@ -99,18 +99,19 @@
             avgUploadTime,
             avgDownloadTime,
         } = dataset;
+        const data = [
+            Number(avgPhotoProcessingTime),
+            Number(avgVideoProcessingTime),
+            Number(avgUploadTime),
+            Number(avgDownloadTime),
+        ].map((value) => (value === 0 ? 0.1 : value));
         return {
             type: 'bar',
             data: {
                 labels: ['Photo Processing', 'Video Processing', 'Upload', 'Download'],
                 datasets: [{
                     label: 'Avg Seconds',
-                    data: [
-                        Number(avgPhotoProcessingTime),
-                        Number(avgVideoProcessingTime),
-                        Number(avgUploadTime),
-                        Number(avgDownloadTime),
-                    ],
+                    data,
                     backgroundColor: ['#0d6efd', '#0d6efd', '#0dcaf0', '#0dcaf0'],
                 }],
             },


### PR DESCRIPTION
## Summary
- map zero values to 0.1 to render bars on logarithmic performance metrics chart

## Testing
- `uv run ruff check --select I --fix`
- `uv run ruff check`
- `uv run ruff format`
- `uv run pytest -n auto`


------
https://chatgpt.com/codex/tasks/task_b_68b83aa4e3e4832e8f0e28d3dbfdde98