### PR TITLE
refactor(video): move watermark speed constants to config

### DIFF
--- a/telegram_auto_poster/config.py
+++ b/telegram_auto_poster/config.py
@@ -245,6 +245,10 @@ VIDEOS_PATH = "videos"
 SCHEDULED_PATH = "scheduled"
 DOWNLOADS_PATH = "downloads"
 
+# Watermark animation speed range in pixels per second
+WATERMARK_MIN_SPEED = 80
+WATERMARK_MAX_SPEED = 120
+
 # Caption appended to posts originating from user suggestions
 SUGGESTION_CAPTION = "Пост из предложки @ooodnakov_memes_suggest_bot"
 

--- a/telegram_auto_poster/media/video.py
+++ b/telegram_auto_poster/media/video.py
@@ -7,7 +7,12 @@ from pathlib import Path
 
 from loguru import logger
 
-from telegram_auto_poster.config import BUCKET_MAIN, VIDEOS_PATH
+from telegram_auto_poster.config import (
+    BUCKET_MAIN,
+    VIDEOS_PATH,
+    WATERMARK_MAX_SPEED,
+    WATERMARK_MIN_SPEED,
+)
 from telegram_auto_poster.utils.general import MinioError
 from telegram_auto_poster.utils.storage import storage
 
@@ -72,8 +77,8 @@ async def add_watermark_to_video(
         # Define diagonal bouncing movement for watermark. Use independent speeds for
         # the horizontal and vertical directions to mimic the CSS animation where the
         # durations differ, producing a less predictable path.
-        speed_x = random.randint(80, 120)
-        speed_y = random.randint(80, 120)
+        speed_x = random.randint(WATERMARK_MIN_SPEED, WATERMARK_MAX_SPEED)
+        speed_y = random.randint(WATERMARK_MIN_SPEED, WATERMARK_MAX_SPEED)
         filter_complex = (
             f"[1]scale={wm_w}:{wm_w}[wm];"
             f"[0][wm]overlay=x='if(gt(mod(t*{speed_x},2*({v_w}-{wm_w})),({v_w}-{wm_w})), "


### PR DESCRIPTION
## Summary
- centralize watermark animation speed bounds in config
- use these constants in video watermark processing

## Testing
- `uv run ruff check --select I --fix`
- `uv run ruff check`
- `uv run ruff format`
- `uv run pytest -n auto`


------
https://chatgpt.com/codex/tasks/task_b_68b84c41c000832e8de969d19afe94d5