### PR TITLE
refactor: extract helper functions for callbacks

### DIFF
--- a/telegram_auto_poster/bot/callbacks.py
+++ b/telegram_auto_poster/bot/callbacks.py
@@ -72,7 +72,7 @@ def _translated_media_type(media_type: str) -> str:
 
 
 async def _notify_submitter(
-    context,
+    context: ContextTypes.DEFAULT_TYPE,
     user_metadata: dict | None,
     media_type: str,
     template: str,
@@ -132,9 +132,13 @@ async def _add_media_hash(
                     cleanup_temp_file(temp_path)
         if media_hash:
             add_approved_hash(media_hash)
+    except MinioError as _e:
+        logger.warning(
+            f"MinIO error while adding approved hash for {file_name} in {context_name}: {_e}"
+        )
     except Exception as _e:
         logger.warning(
-            f"Failed to add approved hash for {file_name} in {context_name}: {_e}"
+            f"Unexpected error when adding approved hash for {file_name} in {context_name}: {_e}"
         )
     return media_hash
 


### PR DESCRIPTION
## Summary
- centralize path extraction, notifications, media hash, and message editing into private helpers
- simplify scheduling, approval, push, and rejection callbacks by using these helpers
- annotate context parameter in `_notify_submitter`
- narrow exception handling in `_add_media_hash`

## Testing
- `uv run ruff check --select I --fix`
- `uv run ruff check`
- `uv run ruff format telegram_auto_poster/bot/callbacks.py`
- `uv run pybabel compile -d telegram_auto_poster/locales`
- `uv run pytest -n auto`


------
https://chatgpt.com/codex/tasks/task_b_68baa91d1698832eab0ac17e3ea7bbb5