### PR TITLE
refactor: centralize path extraction from messages

### DIFF
--- a/telegram_auto_poster/utils/general.py
+++ b/telegram_auto_poster/utils/general.py
@@ -95,7 +95,7 @@ def extract_file_paths(text: str) -> List[str]:
     return results
 
 
-def extract_paths_from_message(message) -> List[str]:
+def extract_paths_from_message(message: Any) -> List[str]:
     """Extract media paths from a Telegram message.
 
     Looks at ``message.caption`` and ``message.text`` to gather all file paths

--- a/test/utils/test_general.py
+++ b/test/utils/test_general.py
@@ -65,6 +65,14 @@ def test_extract_file_paths(text, expected):
             SimpleNamespace(text=None, caption=None),
             [],
         ),
+        (
+            None,
+            [],
+        ),
+        (
+            SimpleNamespace(),
+            [],
+        ),
     ],
 )
 def test_extract_paths_from_message(message, expected):


### PR DESCRIPTION
## Summary
- add explicit `Any` annotation to `extract_paths_from_message`
- cover path extraction helper with additional edge-case tests

## Testing
- `uv run ruff check --select I --fix`
- `uv run ruff check`
- `uv run ruff format`
- `uv run pybabel compile -d telegram_auto_poster/locales`
- `uv run pytest -n auto`


------
https://chatgpt.com/codex/tasks/task_b_68baa93498f0832eaa2c6e83a92259a7