### PR TITLE
refactor: localize approval keyboard

### DIFF
--- a/telegram_auto_poster/bot/bot.py
+++ b/telegram_auto_poster/bot/bot.py
@@ -46,6 +46,12 @@ from telegram_auto_poster.bot.commands import (
 from telegram_auto_poster.bot.handlers import handle_media
 from telegram_auto_poster.config import Config
 from telegram_auto_poster.utils.timezone import now_utc
+from telegram_auto_poster.utils.ui import (
+    CALLBACK_NOTOK,
+    CALLBACK_OK,
+    CALLBACK_PUSH,
+    CALLBACK_SCHEDULE,
+)
 
 
 class TelegramMemeBot:
@@ -118,16 +124,16 @@ class TelegramMemeBot:
         # Register callback handlers - fixed to use exact pattern matching with regex
         logger.info("Registering callback handlers...")
         self.application.add_handler(
-            CallbackQueryHandler(ok_callback, pattern=r"^/ok$")
+            CallbackQueryHandler(ok_callback, pattern=rf"^{CALLBACK_OK}$")
         )
         self.application.add_handler(
-            CallbackQueryHandler(push_callback, pattern=r"^/push$")
+            CallbackQueryHandler(push_callback, pattern=rf"^{CALLBACK_PUSH}$")
         )
         self.application.add_handler(
-            CallbackQueryHandler(notok_callback, pattern=r"^/notok$")
+            CallbackQueryHandler(notok_callback, pattern=rf"^{CALLBACK_NOTOK}$")
         )
         self.application.add_handler(
-            CallbackQueryHandler(schedule_callback, pattern=r"^/schedule$")
+            CallbackQueryHandler(schedule_callback, pattern=rf"^{CALLBACK_SCHEDULE}$")
         )
         self.application.add_handler(
             CallbackQueryHandler(unschedule_callback, pattern=r"^/unschedule:")

--- a/telegram_auto_poster/bot/callbacks.py
+++ b/telegram_auto_poster/bot/callbacks.py
@@ -47,6 +47,12 @@ from telegram_auto_poster.utils.timezone import (
     format_display,
     now_utc,
 )
+from telegram_auto_poster.utils.ui import (
+    CALLBACK_NOTOK,
+    CALLBACK_OK,
+    CALLBACK_PUSH,
+    CALLBACK_SCHEDULE,
+)
 
 
 def _is_streaming_video(file_path: str) -> bool:
@@ -57,7 +63,7 @@ def _is_streaming_video(file_path: str) -> bool:
 async def schedule_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Handle scheduling a post."""
     logger.info(
-        f"Received /schedule callback from user {update.callback_query.from_user.id}"
+        f"Received {CALLBACK_SCHEDULE} callback from user {update.callback_query.from_user.id}"
     )
     query = update.callback_query
     await query.answer()
@@ -151,7 +157,9 @@ async def schedule_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) 
 
 async def ok_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Handle approval: add post to batch"""
-    logger.info(f"Received /ok callback from user {update.callback_query.from_user.id}")
+    logger.info(
+        f"Received {CALLBACK_OK} callback from user {update.callback_query.from_user.id}"
+    )
     logger.debug(f"Callback data: {update.callback_query.data}")
 
     query = update.callback_query
@@ -268,7 +276,7 @@ async def ok_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
 async def push_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Handle direct publish of approved media"""
     logger.info(
-        f"Received /push callback from user {update.callback_query.from_user.id}"
+        f"Received {CALLBACK_PUSH} callback from user {update.callback_query.from_user.id}"
     )
     logger.debug(f"Callback data: {update.callback_query.data}")
 
@@ -368,7 +376,7 @@ async def push_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
 async def notok_callback(update, context) -> None:
     """Handle rejection of media submissions"""
     logger.info(
-        f"Received /notok callback from user {update.callback_query.from_user.id}"
+        f"Received {CALLBACK_NOTOK} callback from user {update.callback_query.from_user.id}"
     )
     logger.debug(f"Callback data: {update.callback_query.data}")
 

--- a/telegram_auto_poster/locales/en/LC_MESSAGES/messages.po
+++ b/telegram_auto_poster/locales/en/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-09-04 12:33+0000\n"
+"POT-Creation-Date: 2025-09-05 09:12+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -14,11 +14,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.17.0\n"
 
-#: telegram_auto_poster/bot/commands.py:40
+#: telegram_auto_poster/bot/commands.py:47
 msgid "Привет! Присылай сюда свои мемы)"
 msgstr "Hello! Send your memes here"
 
-#: telegram_auto_poster/bot/commands.py:56
+#: telegram_auto_poster/bot/commands.py:63
 msgid ""
 "<b>Предложка для @ooodnakov_memes</b>\n"
 "\n"
@@ -32,9 +32,8 @@ msgid ""
 "3. Вы получите уведомление, когда ваш контент будет одобрен или отклонен"
 msgstr ""
 
-#: telegram_auto_poster/bot/commands.py:68
+#: telegram_auto_poster/bot/commands.py:77
 msgid ""
-"\n"
 "<b>Команды администратора:</b>\n"
 "• /stats - Просмотр статистики обработки медиа\n"
 "• /reset_stats - Сбросить ежедневную статистику\n"
@@ -52,66 +51,102 @@ msgid ""
 "• No - Отклонить медиа"
 msgstr ""
 
-#: telegram_auto_poster/bot/commands.py:94
+#: telegram_auto_poster/bot/commands.py:106
 #, python-brace-format
 msgid "This chat ID is: {chat_id}"
 msgstr ""
 
-#: telegram_auto_poster/bot/commands.py:110
+#: telegram_auto_poster/bot/commands.py:122
 msgid "No statistics available."
 msgstr ""
 
-#: telegram_auto_poster/bot/commands.py:115
+#: telegram_auto_poster/bot/commands.py:127
 msgid "Sorry, there was an error generating the statistics report."
 msgstr ""
 
-#: telegram_auto_poster/bot/commands.py:133
+#: telegram_auto_poster/bot/commands.py:145
 msgid "Daily statistics have been reset."
 msgstr ""
 
-#: telegram_auto_poster/bot/commands.py:138
+#: telegram_auto_poster/bot/commands.py:150
 msgid "Sorry, there was an error resetting the statistics."
 msgstr ""
 
-#: telegram_auto_poster/bot/commands.py:155
+#: telegram_auto_poster/bot/commands.py:167
 msgid "Stats saved!"
 msgstr ""
 
-#: telegram_auto_poster/bot/commands.py:159
+#: telegram_auto_poster/bot/commands.py:171
 msgid "Sorry, there was an error saving the statistics."
 msgstr ""
 
-#: telegram_auto_poster/bot/handlers.py:107
-#: telegram_auto_poster/bot/handlers.py:187
+#: telegram_auto_poster/bot/handlers.py:104
+#: telegram_auto_poster/bot/handlers.py:184
 msgid "Этот пост уже есть в канале."
 msgstr ""
 
-#: telegram_auto_poster/bot/handlers.py:133
+#: telegram_auto_poster/bot/handlers.py:130
 msgid ""
 "Спасибо за вашу предложку! Мы рассмотрим её и сообщим вам, если она будет"
 " одобрена."
 msgstr ""
 
-#: telegram_auto_poster/bot/handlers.py:142
+#: telegram_auto_poster/bot/handlers.py:139
 msgid "Произошла ошибка при обработке вашего фото. Пожалуйста, попробуйте позже."
 msgstr ""
 
-#: telegram_auto_poster/bot/handlers.py:213
+#: telegram_auto_poster/bot/handlers.py:210
 msgid ""
 "Спасибо за ваше видео! Мы его рассмотрим и сообщим, если оно будет "
 "одобрено."
 msgstr ""
 
-#: telegram_auto_poster/bot/handlers.py:222
+#: telegram_auto_poster/bot/handlers.py:219
 msgid "Произошла ошибка при обработке вашего видео. Пожалуйста, попробуйте позже."
 msgstr ""
 
-#: telegram_auto_poster/bot/handlers.py:617
+#: telegram_auto_poster/bot/handlers.py:589
 msgid ""
 "Произошла ошибка при обработке вашего сообщения. Пожалуйста, попробуйте "
 "позже."
 msgstr ""
 
+#: telegram_auto_poster/utils/ui.py:20
+msgid "Send to batch!"
+msgstr ""
+
+#: telegram_auto_poster/utils/ui.py:21
+msgid "Schedule"
+msgstr ""
+
+#: telegram_auto_poster/utils/ui.py:24
+msgid "Push!"
+msgstr ""
+
+#: telegram_auto_poster/utils/ui.py:25
+msgid "No!"
+msgstr ""
+
 #~ msgid "Привет"
 #~ msgstr "Hello"
+
+#~ msgid ""
+#~ "\n"
+#~ "<b>Команды администратора:</b>\n"
+#~ "• /stats - Просмотр статистики обработки медиа\n"
+#~ "• /reset_stats - Сбросить ежедневную статистику\n"
+#~ "• /save_stats - Принудительно сохранить статистику\n"
+#~ "• /sendall - Отправить все одобренные"
+#~ " медиафайлы из пакета в целевой канал"
+#~ "\n"
+#~ "• /delete_batch - Удалить текущий пакет медиафайлов\n"
+#~ "• /get - Получить текущий ID чата\n"
+#~ "\n"
+#~ "<b>Проверка контента администратором:</b>\n"
+#~ "При проверке контента вы можете использовать кнопки для:\n"
+#~ "• Send to batch - Добавить медиа в пакет для последующей отправки\n"
+#~ "• Schedule - Добавляет медиа в очередь\n"
+#~ "• Push - Немедленно опубликовать медиа в канале\n"
+#~ "• No - Отклонить медиа"
+#~ msgstr ""
 

--- a/telegram_auto_poster/locales/messages.pot
+++ b/telegram_auto_poster/locales/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-09-04 12:33+0000\n"
+"POT-Creation-Date: 2025-09-05 09:12+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.17.0\n"
 
-#: telegram_auto_poster/bot/commands.py:40
+#: telegram_auto_poster/bot/commands.py:47
 msgid "Привет! Присылай сюда свои мемы)"
 msgstr ""
 
-#: telegram_auto_poster/bot/commands.py:56
+#: telegram_auto_poster/bot/commands.py:63
 msgid ""
 "<b>Предложка для @ooodnakov_memes</b>\n"
 "\n"
@@ -35,9 +35,8 @@ msgid ""
 "3. Вы получите уведомление, когда ваш контент будет одобрен или отклонен"
 msgstr ""
 
-#: telegram_auto_poster/bot/commands.py:68
+#: telegram_auto_poster/bot/commands.py:77
 msgid ""
-"\n"
 "<b>Команды администратора:</b>\n"
 "• /stats - Просмотр статистики обработки медиа\n"
 "• /reset_stats - Сбросить ежедневную статистику\n"
@@ -55,63 +54,79 @@ msgid ""
 "• No - Отклонить медиа"
 msgstr ""
 
-#: telegram_auto_poster/bot/commands.py:94
+#: telegram_auto_poster/bot/commands.py:106
 #, python-brace-format
 msgid "This chat ID is: {chat_id}"
 msgstr ""
 
-#: telegram_auto_poster/bot/commands.py:110
+#: telegram_auto_poster/bot/commands.py:122
 msgid "No statistics available."
 msgstr ""
 
-#: telegram_auto_poster/bot/commands.py:115
+#: telegram_auto_poster/bot/commands.py:127
 msgid "Sorry, there was an error generating the statistics report."
 msgstr ""
 
-#: telegram_auto_poster/bot/commands.py:133
+#: telegram_auto_poster/bot/commands.py:145
 msgid "Daily statistics have been reset."
 msgstr ""
 
-#: telegram_auto_poster/bot/commands.py:138
+#: telegram_auto_poster/bot/commands.py:150
 msgid "Sorry, there was an error resetting the statistics."
 msgstr ""
 
-#: telegram_auto_poster/bot/commands.py:155
+#: telegram_auto_poster/bot/commands.py:167
 msgid "Stats saved!"
 msgstr ""
 
-#: telegram_auto_poster/bot/commands.py:159
+#: telegram_auto_poster/bot/commands.py:171
 msgid "Sorry, there was an error saving the statistics."
 msgstr ""
 
-#: telegram_auto_poster/bot/handlers.py:107
-#: telegram_auto_poster/bot/handlers.py:187
+#: telegram_auto_poster/bot/handlers.py:104
+#: telegram_auto_poster/bot/handlers.py:184
 msgid "Этот пост уже есть в канале."
 msgstr ""
 
-#: telegram_auto_poster/bot/handlers.py:133
+#: telegram_auto_poster/bot/handlers.py:130
 msgid ""
 "Спасибо за вашу предложку! Мы рассмотрим её и сообщим вам, если она будет"
 " одобрена."
 msgstr ""
 
-#: telegram_auto_poster/bot/handlers.py:142
+#: telegram_auto_poster/bot/handlers.py:139
 msgid "Произошла ошибка при обработке вашего фото. Пожалуйста, попробуйте позже."
 msgstr ""
 
-#: telegram_auto_poster/bot/handlers.py:213
+#: telegram_auto_poster/bot/handlers.py:210
 msgid ""
 "Спасибо за ваше видео! Мы его рассмотрим и сообщим, если оно будет "
 "одобрено."
 msgstr ""
 
-#: telegram_auto_poster/bot/handlers.py:222
+#: telegram_auto_poster/bot/handlers.py:219
 msgid "Произошла ошибка при обработке вашего видео. Пожалуйста, попробуйте позже."
 msgstr ""
 
-#: telegram_auto_poster/bot/handlers.py:617
+#: telegram_auto_poster/bot/handlers.py:589
 msgid ""
 "Произошла ошибка при обработке вашего сообщения. Пожалуйста, попробуйте "
 "позже."
+msgstr ""
+
+#: telegram_auto_poster/utils/ui.py:20
+msgid "Send to batch!"
+msgstr ""
+
+#: telegram_auto_poster/utils/ui.py:21
+msgid "Schedule"
+msgstr ""
+
+#: telegram_auto_poster/utils/ui.py:24
+msgid "Push!"
+msgstr ""
+
+#: telegram_auto_poster/utils/ui.py:25
+msgid "No!"
 msgstr ""
 

--- a/telegram_auto_poster/locales/ru/LC_MESSAGES/messages.po
+++ b/telegram_auto_poster/locales/ru/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-09-04 12:33+0000\n"
+"POT-Creation-Date: 2025-09-05 09:12+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ru\n"
@@ -15,11 +15,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.17.0\n"
 
-#: telegram_auto_poster/bot/commands.py:40
+#: telegram_auto_poster/bot/commands.py:47
 msgid "Привет! Присылай сюда свои мемы)"
 msgstr "Привет! Присылай сюда свои мемы)"
 
-#: telegram_auto_poster/bot/commands.py:56
+#: telegram_auto_poster/bot/commands.py:63
 msgid ""
 "<b>Предложка для @ooodnakov_memes</b>\n"
 "\n"
@@ -33,9 +33,8 @@ msgid ""
 "3. Вы получите уведомление, когда ваш контент будет одобрен или отклонен"
 msgstr ""
 
-#: telegram_auto_poster/bot/commands.py:68
+#: telegram_auto_poster/bot/commands.py:77
 msgid ""
-"\n"
 "<b>Команды администратора:</b>\n"
 "• /stats - Просмотр статистики обработки медиа\n"
 "• /reset_stats - Сбросить ежедневную статистику\n"
@@ -53,66 +52,102 @@ msgid ""
 "• No - Отклонить медиа"
 msgstr ""
 
-#: telegram_auto_poster/bot/commands.py:94
+#: telegram_auto_poster/bot/commands.py:106
 #, python-brace-format
 msgid "This chat ID is: {chat_id}"
 msgstr ""
 
-#: telegram_auto_poster/bot/commands.py:110
+#: telegram_auto_poster/bot/commands.py:122
 msgid "No statistics available."
 msgstr ""
 
-#: telegram_auto_poster/bot/commands.py:115
+#: telegram_auto_poster/bot/commands.py:127
 msgid "Sorry, there was an error generating the statistics report."
 msgstr ""
 
-#: telegram_auto_poster/bot/commands.py:133
+#: telegram_auto_poster/bot/commands.py:145
 msgid "Daily statistics have been reset."
 msgstr ""
 
-#: telegram_auto_poster/bot/commands.py:138
+#: telegram_auto_poster/bot/commands.py:150
 msgid "Sorry, there was an error resetting the statistics."
 msgstr ""
 
-#: telegram_auto_poster/bot/commands.py:155
+#: telegram_auto_poster/bot/commands.py:167
 msgid "Stats saved!"
 msgstr ""
 
-#: telegram_auto_poster/bot/commands.py:159
+#: telegram_auto_poster/bot/commands.py:171
 msgid "Sorry, there was an error saving the statistics."
 msgstr ""
 
-#: telegram_auto_poster/bot/handlers.py:107
-#: telegram_auto_poster/bot/handlers.py:187
+#: telegram_auto_poster/bot/handlers.py:104
+#: telegram_auto_poster/bot/handlers.py:184
 msgid "Этот пост уже есть в канале."
 msgstr ""
 
-#: telegram_auto_poster/bot/handlers.py:133
+#: telegram_auto_poster/bot/handlers.py:130
 msgid ""
 "Спасибо за вашу предложку! Мы рассмотрим её и сообщим вам, если она будет"
 " одобрена."
 msgstr ""
 
-#: telegram_auto_poster/bot/handlers.py:142
+#: telegram_auto_poster/bot/handlers.py:139
 msgid "Произошла ошибка при обработке вашего фото. Пожалуйста, попробуйте позже."
 msgstr ""
 
-#: telegram_auto_poster/bot/handlers.py:213
+#: telegram_auto_poster/bot/handlers.py:210
 msgid ""
 "Спасибо за ваше видео! Мы его рассмотрим и сообщим, если оно будет "
 "одобрено."
 msgstr ""
 
-#: telegram_auto_poster/bot/handlers.py:222
+#: telegram_auto_poster/bot/handlers.py:219
 msgid "Произошла ошибка при обработке вашего видео. Пожалуйста, попробуйте позже."
 msgstr ""
 
-#: telegram_auto_poster/bot/handlers.py:617
+#: telegram_auto_poster/bot/handlers.py:589
 msgid ""
 "Произошла ошибка при обработке вашего сообщения. Пожалуйста, попробуйте "
 "позже."
 msgstr ""
 
+#: telegram_auto_poster/utils/ui.py:20
+msgid "Send to batch!"
+msgstr ""
+
+#: telegram_auto_poster/utils/ui.py:21
+msgid "Schedule"
+msgstr ""
+
+#: telegram_auto_poster/utils/ui.py:24
+msgid "Push!"
+msgstr ""
+
+#: telegram_auto_poster/utils/ui.py:25
+msgid "No!"
+msgstr ""
+
 #~ msgid "Привет"
 #~ msgstr "Привет"
+
+#~ msgid ""
+#~ "\n"
+#~ "<b>Команды администратора:</b>\n"
+#~ "• /stats - Просмотр статистики обработки медиа\n"
+#~ "• /reset_stats - Сбросить ежедневную статистику\n"
+#~ "• /save_stats - Принудительно сохранить статистику\n"
+#~ "• /sendall - Отправить все одобренные"
+#~ " медиафайлы из пакета в целевой канал"
+#~ "\n"
+#~ "• /delete_batch - Удалить текущий пакет медиафайлов\n"
+#~ "• /get - Получить текущий ID чата\n"
+#~ "\n"
+#~ "<b>Проверка контента администратором:</b>\n"
+#~ "При проверке контента вы можете использовать кнопки для:\n"
+#~ "• Send to batch - Добавить медиа в пакет для последующей отправки\n"
+#~ "• Schedule - Добавляет медиа в очередь\n"
+#~ "• Push - Немедленно опубликовать медиа в канале\n"
+#~ "• No - Отклонить медиа"
+#~ msgstr ""
 

--- a/telegram_auto_poster/utils/ui.py
+++ b/telegram_auto_poster/utils/ui.py
@@ -1,4 +1,11 @@
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+from telegram_auto_poster.utils.i18n import _
+
+# Callback data constants
+CALLBACK_OK = "/ok"
+CALLBACK_SCHEDULE = "/schedule"
+CALLBACK_PUSH = "/push"
+CALLBACK_NOTOK = "/notok"
 
 
 def approval_keyboard() -> InlineKeyboardMarkup:
@@ -10,12 +17,12 @@ def approval_keyboard() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(
         [
             [
-                InlineKeyboardButton("Send to batch!", callback_data="/ok"),
-                InlineKeyboardButton("Schedule", callback_data="/schedule"),
+                InlineKeyboardButton(_("Send to batch!"), callback_data=CALLBACK_OK),
+                InlineKeyboardButton(_("Schedule"), callback_data=CALLBACK_SCHEDULE),
             ],
             [
-                InlineKeyboardButton("Push!", callback_data="/push"),
-                InlineKeyboardButton("No!", callback_data="/notok"),
+                InlineKeyboardButton(_("Push!"), callback_data=CALLBACK_PUSH),
+                InlineKeyboardButton(_("No!"), callback_data=CALLBACK_NOTOK),
             ],
         ]
     )


### PR DESCRIPTION
## Summary
- centralize callback data constants for approval actions
- localize approval keyboard button labels
- update callbacks and bot registration to use constants

## Testing
- `uv run ruff check --select I --fix`
- `uv run ruff check`
- `uv run ruff format`
- `scripts/i18n.sh`
- `uv run pytest -n auto`


------
https://chatgpt.com/codex/tasks/task_b_68baa925c708832e8a16f542983d6cf4