### PR TITLE
Track submitter sources and add leaderboard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "python-multipart>=0.0.20",
     "Babel>=2.15.0",
     "pytesseract>=0.3.13",
+    "polib>=1.2.0",
 ]
 
 [dependency-groups]

--- a/telegram_auto_poster/bot/callbacks.py
+++ b/telegram_auto_poster/bot/callbacks.py
@@ -211,6 +211,7 @@ async def ok_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
                     chat_id=src_meta.get("chat_id") if src_meta else None,
                     message_id=src_meta.get("message_id") if src_meta else None,
                     media_hash=media_hash,
+                    source_name=src_meta.get("source") if src_meta else None,
                 )
 
                 try:
@@ -324,7 +325,9 @@ async def push_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
                 await storage.delete_file(file_prefix + file_name, BUCKET_MAIN)
 
                 await stats.record_approved(
-                    media_type, filename=file_name, source="push_callback"
+                    media_type,
+                    filename=file_name,
+                    source=user_metadata.get("source") if user_metadata else None,
                 )
                 sent_counts[media_type] += 1
 
@@ -413,7 +416,9 @@ async def notok_callback(update, context) -> None:
                 )
 
             await stats.record_rejected(
-                media_type, filename=file_name, source="notok_callback"
+                media_type,
+                filename=file_name,
+                source=user_metadata.get("source") if user_metadata else None,
             )
 
             if (

--- a/telegram_auto_poster/bot/commands.py
+++ b/telegram_auto_poster/bot/commands.py
@@ -222,8 +222,10 @@ async def ok_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
 
         # Record stats
         media_type = "photo" if ext.lower() in [".jpg", ".jpeg", ".png"] else "video"
+        meta = await storage.get_submission_metadata(object_name)
+        source_name = meta.get("source") if meta else None
         await stats.record_approved(
-            media_type, filename=object_name, source="ok_command"
+            media_type, filename=object_name, source=source_name
         )
 
     except MinioError as e:
@@ -260,8 +262,10 @@ async def notok_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
             await update.message.reply_text("Post disapproved!")
 
             # Record stats
+            meta = await storage.get_submission_metadata(object_name)
+            source_name = meta.get("source") if meta else None
             await stats.record_rejected(
-                media_type, filename=object_name, source="notok_command"
+                media_type, filename=object_name, source=source_name
             )
         else:
             await update.message.reply_text("No post found to disapprove.")
@@ -590,13 +594,13 @@ async def send_batch_command(update, context):
                 base_name = item["base_name"]
                 file_obj.close()
 
+                user_metadata = await storage.get_submission_metadata(base_name)
+                source_name = user_metadata.get("source") if user_metadata else None
                 await stats.record_approved(
                     media_type,
                     filename=base_name,
-                    source="send_batch_command",
+                    source=source_name,
                 )
-
-                user_metadata = await storage.get_submission_metadata(base_name)
                 if user_metadata and not user_metadata.get("notified"):
                     user_id = user_metadata.get("user_id")
                     if user_id and user_id not in notified_users:

--- a/telegram_auto_poster/client/client.py
+++ b/telegram_auto_poster/client/client.py
@@ -77,6 +77,11 @@ class TelegramMemeClient:
                 return
 
             files: list[tuple[str, str, str]] = []
+            source_name = (
+                getattr(event.chat, "username", None)
+                or getattr(event.chat, "title", None)
+                or str(event.chat_id)
+            )
             try:
                 for message in event.messages:
                     file_path = None
@@ -107,6 +112,7 @@ class TelegramMemeClient:
                         files,
                         self.bot_chat_id,
                         self.application,
+                        source_name,
                     )
             except Exception:
                 log.exception("Failed to handle album")
@@ -137,6 +143,11 @@ class TelegramMemeClient:
                 return
 
             file_path = None
+            source_name = (
+                getattr(event.chat, "username", None)
+                or getattr(event.chat, "title", None)
+                or str(event.chat_id)
+            )
             try:
                 if isinstance(event.media, types.MessageMediaPhoto):
                     log = log.bind(media_type="photo")
@@ -151,6 +162,7 @@ class TelegramMemeClient:
                         os.path.basename(file_path),
                         self.bot_chat_id,
                         self.application,
+                        user_metadata={"media_type": "photo", "source": source_name},
                     )
                 elif isinstance(event.media, types.MessageMediaDocument):
                     if event.media.document:
@@ -166,6 +178,10 @@ class TelegramMemeClient:
                             os.path.basename(file_path),
                             self.bot_chat_id,
                             self.application,
+                            user_metadata={
+                                "media_type": "video",
+                                "source": source_name,
+                            },
                         )
             except Exception:
                 log.exception("Failed to handle message")

--- a/telegram_auto_poster/media/photo.py
+++ b/telegram_auto_poster/media/photo.py
@@ -74,6 +74,7 @@ async def add_watermark_to_image(
             message_id=meta.get("message_id") if meta else None,
             media_hash=media_hash,
             group_id=group_id,
+            source_name=meta.get("source") if meta else None,
         )
         if not uploaded:
             raise MinioError(

--- a/telegram_auto_poster/media/video.py
+++ b/telegram_auto_poster/media/video.py
@@ -139,6 +139,7 @@ async def add_watermark_to_video(
             message_id=meta.get("message_id") if meta else None,
             media_hash=media_hash,
             group_id=group_id,
+            source_name=meta.get("source") if meta else None,
         )
         if not uploaded:
             raise MinioError(

--- a/telegram_auto_poster/web/templates/base.html
+++ b/telegram_auto_poster/web/templates/base.html
@@ -39,6 +39,9 @@
                 <li class="nav-item">
                     <a class="nav-link" href="/stats">{{ _('Stats') }}</a>
                 </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="/leaderboard">{{ _('Leaderboard') }}</a>
+                </li>
             </ul>
         </div>
     </div>

--- a/telegram_auto_poster/web/templates/leaderboard.html
+++ b/telegram_auto_poster/web/templates/leaderboard.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Leaderboard</h1>
+<div class="row">
+  <div class="col-md-4">
+    <h2>Top Submitters</h2>
+    <table class="table table-striped">
+      <thead><tr><th>Source</th><th>Count</th><th>%</th></tr></thead>
+      <tbody>
+        {% for item in submitted %}
+        <tr><td>{{ item.source }}</td><td>{{ item.count }}</td><td>{{ '%.1f'|format(item.percent) }}%</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  <div class="col-md-4">
+    <h2>Top Approved</h2>
+    <table class="table table-striped">
+      <thead><tr><th>Source</th><th>Count</th><th>%</th></tr></thead>
+      <tbody>
+        {% for item in approved %}
+        <tr><td>{{ item.source }}</td><td>{{ item.count }}</td><td>{{ '%.1f'|format(item.percent) }}%</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  <div class="col-md-4">
+    <h2>Top Rejected</h2>
+    <table class="table table-striped">
+      <thead><tr><th>Source</th><th>Count</th><th>%</th></tr></thead>
+      <tbody>
+        {% for item in rejected %}
+        <tr><td>{{ item.source }}</td><td>{{ item.count }}</td><td>{{ '%.1f'|format(item.percent) }}%</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endblock %}

--- a/test/bot/test_process_media_group.py
+++ b/test/bot/test_process_media_group.py
@@ -47,7 +47,7 @@ async def test_process_media_group(mocker, tmp_path):
         ("video1.mp4", "video1.mp4", "video"),
     ]
 
-    await process_media_group("caption", files, "chat", application)
+    await process_media_group("caption", files, "chat", application, "src")
 
     send_media_group_mock.assert_awaited_once()
     args, kwargs = send_media_group_mock.await_args

--- a/test/utils/test_stats.py
+++ b/test/utils/test_stats.py
@@ -95,3 +95,19 @@ async def test_force_save_swallows_errors(stats_instance, mocker):
     await stats_instance.force_save()
 
     mock_save.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_leaderboard(stats_instance):
+    await stats_instance.record_submission_by("alice")
+    await stats_instance.record_submission_by("alice")
+    await stats_instance.record_submission_by("bob")
+    await stats_instance.record_approved("photo", source="alice")
+    await stats_instance.record_rejected("video", source="bob")
+    submitted = await stats_instance.get_leaderboard("submitted")
+    assert submitted[0]["source"] == "alice"
+    assert submitted[0]["count"] == 2
+    approved = await stats_instance.get_leaderboard("approved")
+    assert approved[0]["source"] == "alice"
+    rejected = await stats_instance.get_leaderboard("rejected")
+    assert rejected[0]["source"] == "bob"

--- a/test/utils/test_storage.py
+++ b/test/utils/test_storage.py
@@ -47,6 +47,12 @@ def patch_redis_client(mocker: MockerFixture, mock_redis_client: FakeRedis):
         "telegram_auto_poster.utils.storage.get_async_redis_client",
         return_value=mock_redis_client,
     )
+    stats_mock = mocker.MagicMock()
+    stats_mock.record_submission_by = mocker.AsyncMock()
+    mocker.patch(
+        "telegram_auto_poster.utils.storage.stats_module.stats",
+        stats_mock,
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- track submitter channel/username in stored metadata and stats
- add leaderboard API and web view with top submitters, approvals and rejections
- expose leaderboard link in dashboard navigation
- compile translations from `.po` files at runtime and drop committed `.mo` binaries

## Testing
- `uv run ruff check --select I --fix`
- `uv run ruff check`
- `uv run ruff format`
- `uv run pytest -n auto`


------
https://chatgpt.com/codex/tasks/task_b_68baa8d73898832e8d13fbb024ab81f5