### PR TITLE
feat: track submission sources and leaderboard

### DIFF
--- a/telegram_auto_poster/bot/handlers.py
+++ b/telegram_auto_poster/bot/handlers.py
@@ -248,10 +248,10 @@ async def _send_to_review(
     if user_metadata:
         await storage.store_submission_metadata(
             processed_name,
-            user_metadata["user_id"],
-            user_metadata["chat_id"],
-            user_metadata["media_type"],
-            user_metadata["message_id"],
+            user_metadata.get("user_id"),
+            user_metadata.get("chat_id"),
+            user_metadata.get("media_type"),
+            user_metadata.get("message_id"),
             media_hash=media_hash,
             caption=caption,
             source=user_metadata.get("source"),

--- a/telegram_auto_poster/utils/stats.py
+++ b/telegram_auto_poster/utils/stats.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import datetime
+import heapq
 from typing import Optional
 
 from telegram_auto_poster.utils.db import (
@@ -243,11 +244,9 @@ class MediaStats:
                     "rejected_pct": (r / s * 100) if s else 0,
                 }
             )
-        subs_sorted = sorted(entries, key=lambda x: x["submissions"], reverse=True)[
-            :limit
-        ]
-        appr_sorted = sorted(entries, key=lambda x: x["approved"], reverse=True)[:limit]
-        rej_sorted = sorted(entries, key=lambda x: x["rejected"], reverse=True)[:limit]
+        subs_sorted = heapq.nlargest(limit, entries, key=lambda x: x["submissions"])
+        appr_sorted = heapq.nlargest(limit, entries, key=lambda x: x["approved"])
+        rej_sorted = heapq.nlargest(limit, entries, key=lambda x: x["rejected"])
         return {
             "submissions": subs_sorted,
             "approved": appr_sorted,

--- a/telegram_auto_poster/web/templates/leaderboard.html
+++ b/telegram_auto_poster/web/templates/leaderboard.html
@@ -1,67 +1,35 @@
 {% extends "base.html" %}
+{% macro render_table(title, items, columns) %}
+<h2>{{ _(title) }}</h2>
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>{{ _('Source') }}</th>
+      {% for field, label in columns %}
+      <th>{{ _(label) }}</th>
+      {% endfor %}
+    </tr>
+  </thead>
+  <tbody>
+  {% for item in items %}
+    <tr>
+      <td>{{ item.source }}</td>
+      {% for field, label in columns %}
+      <td>
+        {{ attribute(item, field) }}
+        {% if field != 'submissions' %}
+        ({{ '%.1f'|format(attribute(item, field + '_pct')) }}%)
+        {% endif %}
+      </td>
+      {% endfor %}
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endmacro %}
 {% block content %}
 <h1>{{ _('Leaderboard') }}</h1>
-<h2>{{ _('Most Submissions') }}</h2>
-<table class="table table-striped">
-  <thead>
-    <tr>
-      <th>{{ _('Source') }}</th>
-      <th>{{ _('Submissions') }}</th>
-      <th>{{ _('Approved') }}</th>
-      <th>{{ _('Rejected') }}</th>
-    </tr>
-  </thead>
-  <tbody>
-  {% for item in submissions %}
-    <tr>
-      <td>{{ item.source }}</td>
-      <td>{{ item.submissions }}</td>
-      <td>{{ item.approved }} ({{ '%.1f'|format(item.approved_pct) }}%)</td>
-      <td>{{ item.rejected }} ({{ '%.1f'|format(item.rejected_pct) }}%)</td>
-    </tr>
-  {% endfor %}
-  </tbody>
-</table>
-<h2>{{ _('Most Approved') }}</h2>
-<table class="table table-striped">
-  <thead>
-    <tr>
-      <th>{{ _('Source') }}</th>
-      <th>{{ _('Approved') }}</th>
-      <th>{{ _('Submissions') }}</th>
-      <th>{{ _('Rejected') }}</th>
-    </tr>
-  </thead>
-  <tbody>
-  {% for item in approved %}
-    <tr>
-      <td>{{ item.source }}</td>
-      <td>{{ item.approved }} ({{ '%.1f'|format(item.approved_pct) }}%)</td>
-      <td>{{ item.submissions }}</td>
-      <td>{{ item.rejected }} ({{ '%.1f'|format(item.rejected_pct) }}%)</td>
-    </tr>
-  {% endfor %}
-  </tbody>
-</table>
-<h2>{{ _('Most Rejected') }}</h2>
-<table class="table table-striped">
-  <thead>
-    <tr>
-      <th>{{ _('Source') }}</th>
-      <th>{{ _('Rejected') }}</th>
-      <th>{{ _('Submissions') }}</th>
-      <th>{{ _('Approved') }}</th>
-    </tr>
-  </thead>
-  <tbody>
-  {% for item in rejected %}
-    <tr>
-      <td>{{ item.source }}</td>
-      <td>{{ item.rejected }} ({{ '%.1f'|format(item.rejected_pct) }}%)</td>
-      <td>{{ item.submissions }}</td>
-      <td>{{ item.approved }} ({{ '%.1f'|format(item.approved_pct) }}%)</td>
-    </tr>
-  {% endfor %}
-  </tbody>
-</table>
+{{ render_table('Most Submissions', submissions, [('submissions','Submissions'), ('approved','Approved'), ('rejected','Rejected')]) }}
+{{ render_table('Most Approved', approved, [('approved','Approved'), ('submissions','Submissions'), ('rejected','Rejected')]) }}
+{{ render_table('Most Rejected', rejected, [('rejected','Rejected'), ('submissions','Submissions'), ('approved','Approved')]) }}
 {% endblock %}

--- a/test/utils/test_stats.py
+++ b/test/utils/test_stats.py
@@ -1,23 +1,110 @@
-import pytest
 import fakeredis.aioredis
+import pytest
+import pytest_asyncio
+
+from telegram_auto_poster.utils.db import _redis_key, _redis_meta_key
 from telegram_auto_poster.utils.stats import MediaStats
 
 
-@pytest.mark.asyncio
-async def test_leaderboard(mocker):
+@pytest_asyncio.fixture
+async def stats_instance(mocker):
     fake = fakeredis.aioredis.FakeRedis(decode_responses=True)
     mocker.patch(
         "telegram_auto_poster.utils.stats.get_async_redis_client", return_value=fake
     )
     MediaStats._instance = None
-    stats = MediaStats()
-    await stats.record_submission("alice")
-    await stats.record_submission("alice")
-    await stats.record_submission("bob")
-    await stats.record_approved("photo", source="alice")
-    await stats.record_rejected("video", source="bob")
-    lb = await stats.get_leaderboard()
+    inst = MediaStats()
+    await inst.r.flushdb()
+    yield inst
+    await inst.r.flushdb()
+    MediaStats._instance = None
+
+
+@pytest.mark.asyncio
+async def test_leaderboard(stats_instance):
+    await stats_instance.record_submission("alice")
+    await stats_instance.record_submission("alice")
+    await stats_instance.record_submission("bob")
+    await stats_instance.record_approved("photo", source="alice")
+    await stats_instance.record_rejected("video", source="bob")
+    lb = await stats_instance.get_leaderboard()
     assert lb["submissions"][0]["source"] == "alice"
     assert lb["submissions"][0]["submissions"] == 2
     assert lb["approved"][0]["source"] == "alice"
     assert lb["rejected"][0]["source"] == "bob"
+
+
+@pytest.mark.asyncio
+async def test_rates(stats_instance):
+    daily = {
+        "photos_processed": 5,
+        "videos_processed": 5,
+        "photos_approved": 3,
+        "videos_approved": 2,
+        "media_received": 10,
+        "processing_errors": 1,
+        "storage_errors": 1,
+        "telegram_errors": 0,
+    }
+    assert await stats_instance.get_success_rate_24h(daily) == pytest.approx(80.0)
+
+    await stats_instance._increment("photos_processed", scope="total", count=10)
+    await stats_instance._increment("photos_approved", scope="total", count=7)
+    await stats_instance._increment("videos_approved", scope="total", count=1)
+    assert await stats_instance.get_approval_rate_total() == pytest.approx(80.0)
+
+
+@pytest.mark.asyncio
+async def test_get_busiest_hour(stats_instance):
+    await stats_instance.r.set(_redis_key("hourly", "2"), 3)
+    await stats_instance.r.set(_redis_key("hourly", "5"), 7)
+    assert await stats_instance.get_busiest_hour() == (5, 7)
+
+
+@pytest.mark.asyncio
+async def test_generate_stats_report_sections(stats_instance):
+    for name in ("photos_processed", "videos_processed"):
+        await stats_instance._increment(name)
+        await stats_instance._increment(name, scope="total")
+
+    await stats_instance._record_duration("photo_processing", 1.2)
+    await stats_instance._record_duration("upload", 0.5)
+
+    report = await stats_instance.generate_stats_report()
+
+    assert "<b>Last 24 Hours:</b>" in report
+    assert "<b>Performance Metrics:</b>" in report
+    assert "<b>All-Time Totals:</b>" in report
+    assert report.count("<b>Photos Processed:</b> 1") == 2
+    assert report.count("<b>Videos Processed:</b> 1") == 2
+    assert "<b>Avg Photo Processing:</b> 1.20s" in report
+    assert "<b>Avg Upload:</b> 0.50s" in report
+
+
+@pytest.mark.asyncio
+async def test_reset_daily_stats_clears_counters(stats_instance):
+    for name in stats_instance.names:
+        await stats_instance._increment(name)
+    await stats_instance.r.set(_redis_key("hourly", "1"), 5)
+    await stats_instance.r.set(_redis_meta_key(), "old-dummy-value")
+    old_meta = await stats_instance.r.get(_redis_meta_key())
+
+    await stats_instance.reset_daily_stats()
+
+    for name in stats_instance.names:
+        assert await stats_instance.r.get(_redis_key("daily", name)) == "0"
+    for hour in range(24):
+        assert await stats_instance.r.get(_redis_key("hourly", str(hour))) is None
+
+    new_meta = await stats_instance.r.get(_redis_meta_key())
+    assert new_meta and new_meta != old_meta
+
+
+@pytest.mark.asyncio
+async def test_force_save_swallows_errors(stats_instance, mocker):
+    mock_save = mocker.AsyncMock(side_effect=Exception("boom"))
+    mocker.patch.object(stats_instance.r, "save", mock_save)
+
+    await stats_instance.force_save()
+
+    mock_save.assert_awaited_once()


### PR DESCRIPTION
## Summary
- restore MediaStats tests and add leaderboard coverage
- factor out source name helper and handle partial user metadata
- optimize leaderboard queries and template

## Testing
- `uv run ruff check --select I --fix`
- `uv run ruff check`
- `uv run ruff format`
- `uv run pytest -n auto`


------
https://chatgpt.com/codex/tasks/task_b_68bae0b508d0832eab33aee11e0ed37b