### PR TITLE
feat: add branding and watermark configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,17 @@ Follow these steps to get running fast. For expanded docs, see the Wiki.
    ./run_bg.sh
    ```
 
+## Configuration highlights
+
+`config.ini` controls most behaviour. In addition to credentials, you can now:
+
+- Configure attribution strings and the default suggestion caption under `[Branding]`.
+- Change watermark assets, relative size, and transparency for images via `[WatermarkImage]`.
+- Tune video watermark path, size range, and animation speed in `[WatermarkVideo]`.
+
+Every option can also be overridden with environment variables (e.g. `BRANDING_ATTRIBUTION`,
+`WATERMARK_IMAGE_PATH`).
+
 ## Documentation & Wiki
 
 - Wiki (GitHub): https://github.com/ooodnakov/telegram_meme_autoposter/wiki

--- a/config.example.ini
+++ b/config.example.ini
@@ -49,3 +49,19 @@ model = gemini-1.5-flash
 enabled = false
 target_lang = ru
 
+[Branding]
+attribution = t.me/ooodnakov_memes
+suggestion_caption = Пост из предложки @ooodnakov_memes_suggest_bot
+
+[WatermarkImage]
+path = wm.png
+size_ratio = 0.1
+opacity = 40
+
+[WatermarkVideo]
+path = wm.png
+min_size_percent = 15
+max_size_percent = 25
+min_speed = 80
+max_speed = 120
+

--- a/test/media/test_media.py
+++ b/test/media/test_media.py
@@ -63,9 +63,13 @@ async def test_add_watermark_to_image(mocker, sample_image):
     # Check that the EXIF data was correct
     mock_piexif_dump.assert_called_once()
     exif_data = mock_piexif_dump.call_args[0][0]
-    assert exif_data["0th"][270] == "t.me/ooodnakov_memes"  # ImageDescription
-    assert exif_data["0th"][315] == "t.me/ooodnakov_memes"  # Artist
-    assert exif_data["0th"][33432] == "t.me/ooodnakov_memes"  # Copyright
+    from telegram_auto_poster.config import CONFIG
+
+    attribution = CONFIG.branding.attribution
+    if attribution:
+        assert exif_data["0th"][270] == attribution  # ImageDescription
+        assert exif_data["0th"][315] == attribution  # Artist
+        assert exif_data["0th"][33432] == attribution  # Copyright
 
 
 @pytest.mark.asyncio

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -240,3 +240,68 @@ session_secret = secret
     config_module = importlib.import_module("telegram_auto_poster.config")
     conf = config_module.load_config()
     assert conf.bot.prompt_target_channel is True
+
+
+def test_branding_section(tmp_path, monkeypatch):
+    write_config(
+        tmp_path / "config.ini",
+        """
+[Telegram]
+api_id = 123
+api_hash = aaa
+username = test
+target_channels = @test
+[Bot]
+bot_token = token
+bot_username = user
+bot_chat_id = 1
+[Chats]
+selected_chats = @test1, @test2
+luba_chat = @luba
+[Web]
+session_secret = secret
+[Branding]
+attribution = example.com/brand
+suggestion_caption = Custom caption
+""",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("CONFIG_PATH", str(tmp_path / "config.ini"))
+    sys.modules.pop("telegram_auto_poster.config", None)
+    config_module = importlib.import_module("telegram_auto_poster.config")
+    conf = config_module.load_config()
+    assert conf.branding.attribution == "example.com/brand"
+    assert conf.branding.suggestion_caption == "Custom caption"
+
+
+def test_watermark_env_overrides(tmp_path, monkeypatch):
+    write_config(
+        tmp_path / "config.ini",
+        """
+[Telegram]
+api_id = 123
+api_hash = aaa
+username = test
+target_channels = @test
+[Bot]
+bot_token = token
+bot_username = user
+bot_chat_id = 1
+[Chats]
+selected_chats = @test1, @test2
+luba_chat = @luba
+[Web]
+session_secret = secret
+""",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("CONFIG_PATH", str(tmp_path / "config.ini"))
+    monkeypatch.setenv("WATERMARK_IMAGE_SIZE_RATIO", "0.25")
+    monkeypatch.setenv("WATERMARK_VIDEO_MIN_SPEED", "10")
+    monkeypatch.setenv("WATERMARK_VIDEO_MAX_SPEED", "20")
+    sys.modules.pop("telegram_auto_poster.config", None)
+    config_module = importlib.import_module("telegram_auto_poster.config")
+    conf = config_module.load_config()
+    assert conf.watermark_image.size_ratio == 0.25
+    assert conf.watermark_video.min_speed == 10
+    assert conf.watermark_video.max_speed == 20


### PR DESCRIPTION
## Summary
- add configurable branding, watermark image, and watermark video sections to config loading and environment overrides
- update media processing to use configurable watermark assets and attribution data
- document the new options and cover them with configuration and media tests

## Testing
- uv run ruff check --select I --fix
- uv run ruff format
- uv run ruff check
- uv run pytest -n auto

------
https://chatgpt.com/codex/tasks/task_b_68d1702a2964832cb4227700537b17bc