### PR TITLE
Fix admin id parsing for web auth

### DIFF
--- a/telegram_auto_poster/config.py
+++ b/telegram_auto_poster/config.py
@@ -270,8 +270,10 @@ def _load_env() -> dict[str, Any]:
             env_data[section] = value
             continue
         env_section = env_data.setdefault(section, {})
-        if field in {"selected_chats", "admin_ids", "target_channels"}:
+        if field in {"selected_chats", "target_channels"}:
             env_section[field] = [x.strip() for x in value.split(",") if x.strip()]
+        elif field == "admin_ids":
+            env_section[field] = [int(x.strip()) for x in value.split(",") if x.strip()]
         elif field == "users":
             env_section[field] = _parse_i18n_users(value)
         else:

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -213,6 +213,35 @@ quiet_hours_end = 8
     assert conf.schedule.quiet_hours_start == 5
 
 
+def test_env_admin_ids_cast_to_int(tmp_path, monkeypatch):
+    write_config(
+        tmp_path / "config.ini",
+        """
+[Telegram]
+api_id = 123
+api_hash = aaa
+username = test
+target_channels = @test
+[Bot]
+bot_token = token
+bot_username = user
+bot_chat_id = 1
+[Chats]
+selected_chats = @test1, @test2
+luba_chat = @luba
+[Web]
+session_secret = secret
+""",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("CONFIG_PATH", str(tmp_path / "config.ini"))
+    monkeypatch.setenv("BOT_ADMIN_IDS", "10, 20")
+    sys.modules.pop("telegram_auto_poster.config", None)
+    config_module = importlib.import_module("telegram_auto_poster.config")
+    conf = config_module.load_config()
+    assert conf.bot.admin_ids == [10, 20]
+
+
 def test_prompt_target_channel_config(tmp_path, monkeypatch):
     write_config(
         tmp_path / "config.ini",


### PR DESCRIPTION
## Summary
- ensure BOT_ADMIN_IDS provided via environment variables are parsed as integers
- add regression test confirming admin ids loaded from env remain numeric

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_b_68d17042a424832cbe12947c845be794