### PR TITLE
Remove rejection confirmation dialog from dashboard review

### DIFF
--- a/telegram_auto_poster/web/templates/_post_grid.html
+++ b/telegram_auto_poster/web/templates/_post_grid.html
@@ -41,7 +41,6 @@
                 method="post"
                 action="/action"
                 data-bg="true"
-                onsubmit="return confirm('{{ _('Reject this item?') }}');"
             >
                 {% for media in p['items'] %}
                 <input type="hidden" name="paths" value="{{ media.path }}" />


### PR DESCRIPTION
## Summary
- remove the browser confirmation prompt when choosing the "No" action in the dashboard review grid

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d6fbc931fc832cad7b5c386349e45a