### PR TITLE
Add manual batch scheduling control

### DIFF
--- a/telegram_auto_poster/bot/commands.py
+++ b/telegram_auto_poster/bot/commands.py
@@ -354,7 +354,9 @@ async def untrash_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     paths = extract_paths_from_message(target_message)
     if not paths:
         await update.message.reply_text(
-            _("No trashed media paths found. Reply to a trash message or include paths."),
+            _(
+                "No trashed media paths found. Reply to a trash message or include paths."
+            ),
         )
         return
 
@@ -365,9 +367,7 @@ async def untrash_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         except Exception as exc:
             logger.error(f"Failed to restore {path} from trash via command: {exc}")
             await update.message.reply_text(
-                _("Failed to restore {path}: {error}").format(
-                    path=path, error=str(exc)
-                )
+                _("Failed to restore {path}: {error}").format(path=path, error=str(exc))
             )
 
     if restored:

--- a/telegram_auto_poster/utils/trash.py
+++ b/telegram_auto_poster/utils/trash.py
@@ -52,7 +52,9 @@ async def move_to_trash(path: str) -> tuple[str, datetime, datetime]:
     """Move ``path`` to the trash and return new path with timestamps."""
 
     _detect_media_type(path)
-    processed_path = path if not path.startswith(f"{TRASH_PATH}/") else _processed_path_for(path)
+    processed_path = (
+        path if not path.startswith(f"{TRASH_PATH}/") else _processed_path_for(path)
+    )
     trash_path = _trash_path_for(processed_path)
     file_name = os.path.basename(processed_path)
 

--- a/telegram_auto_poster/web/app.py
+++ b/telegram_auto_poster/web/app.py
@@ -324,11 +324,13 @@ async def _gather_trash(*, offset: int = 0, limit: int | None = None) -> list[di
             if expires_display and not entry.get("expires_at"):
                 entry["expires_at"] = expires_display
         else:
-            posts.append({
-                "items": [item],
-                "trashed_at": trashed_display,
-                "expires_at": expires_display,
-            })
+            posts.append(
+                {
+                    "items": [item],
+                    "trashed_at": trashed_display,
+                    "expires_at": expires_display,
+                }
+            )
     posts.extend(grouped.values())
     return posts
 

--- a/telegram_auto_poster/web/templates/batch.html
+++ b/telegram_auto_poster/web/templates/batch.html
@@ -6,15 +6,55 @@
     <a class="btn btn-sm btn-outline-secondary" href="/batch{{ query_suffix }}">{{ _('Refresh') }}</a>
 </div>
 {% if posts %}
+{% set ns = namespace(paths=[]) %}
+{% for post in posts %}
+    {% for media in post['items'] %}
+        {% set ns.paths = ns.paths + [media.path] %}
+    {% endfor %}
+{% endfor %}
 <form
     method="post"
     action="/batch/send"
     onsubmit="return confirm('{{ _('Send whole batch?') }}');"
 >
-    <button class="btn btn-primary btn-lg w-100 mb-3" type="submit">
+    <button class="btn btn-primary btn-lg w-100 mb-2" type="submit">
         {{ _('Send Batch') }}
     </button>
 </form>
+<button
+    class="btn btn-outline-secondary w-100 mb-3"
+    type="button"
+    data-bs-toggle="collapse"
+    data-bs-target="#manual-schedule-batch"
+    aria-expanded="false"
+    aria-controls="manual-schedule-batch"
+>
+    {{ _('Manual Schedule Batch') }}
+</button>
+<div class="collapse" id="manual-schedule-batch">
+    <form
+        method="post"
+        action="/batch/manual_schedule"
+        data-bg="true"
+        class="card card-body mb-3 gap-2"
+    >
+        {% for path in ns.paths %}
+        <input type="hidden" name="paths" value="{{ path }}" />
+        {% endfor %}
+        <input type="hidden" name="origin" value="batch" />
+        <label class="form-label" for="manual-schedule-batch-input">{{ _('Start time') }}</label>
+        <div class="d-flex flex-column flex-sm-row gap-2">
+            <input
+                id="manual-schedule-batch-input"
+                type="text"
+                name="scheduled_at"
+                class="form-control form-control-sm datetime-picker"
+                placeholder="{{ _('YYYY-MM-DD HH:MM') }}"
+            />
+            <button class="btn btn-sm btn-success" type="submit">{{ _('Save') }}</button>
+        </div>
+    </form>
+</div>
 {% endif %}
 <div id="batch-grid">
     {% set origin = "batch" %}


### PR DESCRIPTION
## Summary
- add a collapsible manual scheduling form that targets every item in the batch at once
- reuse the existing datetime picker styling so administrators can pick the start time easily

## Testing
- uv run pytest -n auto

------
https://chatgpt.com/codex/tasks/task_b_68d81c376730832c9a240fb2c3dbaddf