### PR TITLE
Enable language switching in web dashboard

### DIFF
--- a/telegram_auto_poster/locales/en/LC_MESSAGES/messages.po
+++ b/telegram_auto_poster/locales/en/LC_MESSAGES/messages.po
@@ -273,6 +273,14 @@ msgstr ""
 msgid "Telegram Autoposter"
 msgstr ""
 
+#: telegram_auto_poster/web/templates/base.html:52
+msgid "Language:"
+msgstr ""
+
+#: telegram_auto_poster/web/templates/base.html:55
+msgid "Change language"
+msgstr ""
+
 #: telegram_auto_poster/web/templates/base.html:25
 msgid "Home"
 msgstr ""

--- a/telegram_auto_poster/locales/messages.pot
+++ b/telegram_auto_poster/locales/messages.pot
@@ -276,6 +276,14 @@ msgstr ""
 msgid "Telegram Autoposter"
 msgstr ""
 
+#: telegram_auto_poster/web/templates/base.html:52
+msgid "Language:"
+msgstr ""
+
+#: telegram_auto_poster/web/templates/base.html:55
+msgid "Change language"
+msgstr ""
+
 #: telegram_auto_poster/web/templates/base.html:25
 msgid "Home"
 msgstr ""

--- a/telegram_auto_poster/locales/ru/LC_MESSAGES/messages.po
+++ b/telegram_auto_poster/locales/ru/LC_MESSAGES/messages.po
@@ -276,6 +276,14 @@ msgstr ""
 msgid "Telegram Autoposter"
 msgstr ""
 
+#: telegram_auto_poster/web/templates/base.html:52
+msgid "Language:"
+msgstr "Язык:"
+
+#: telegram_auto_poster/web/templates/base.html:55
+msgid "Change language"
+msgstr "Сменить язык"
+
 #: telegram_auto_poster/web/templates/base.html:25
 msgid "Home"
 msgstr ""

--- a/telegram_auto_poster/web/templates/base.html
+++ b/telegram_auto_poster/web/templates/base.html
@@ -47,10 +47,7 @@
                 </li>
             </ul>
             <div class="d-flex align-items-center ms-auto">
-                {% set current_lang = request.session.get('language', DEFAULT_LANGUAGE) %}
-                {% if current_lang not in LANGUAGES %}
-                    {% set current_lang = DEFAULT_LANGUAGE %}
-                {% endif %}
+                {% set current_lang = request.state.language %}
                 <span class="navbar-text text-white-50 me-2">{{ _('Language:') }} {{ get_language_label(current_lang) or current_lang }}</span>
                 <form method="post" action="/language" class="mb-0 d-inline">
                     <input type="hidden" name="lang" value="{{ cycle_language(current_lang) }}">

--- a/telegram_auto_poster/web/templates/base.html
+++ b/telegram_auto_poster/web/templates/base.html
@@ -46,13 +46,25 @@
                     <a class="nav-link" href="/leaderboard">{{ _('Leaderboard') }}</a>
                 </li>
             </ul>
-            <ul class="navbar-nav ms-auto">
-                {% if request.session.get('user_id') %}
-                <li class="nav-item"><a class="nav-link" href="/logout">{{ _('Logout') }}</a></li>
-                {% else %}
-                <li class="nav-item"><a class="nav-link" href="/login">{{ _('Login') }}</a></li>
+            <div class="d-flex align-items-center ms-auto">
+                {% set current_lang = request.session.get('language', DEFAULT_LANGUAGE) %}
+                {% if current_lang not in LANGUAGES %}
+                    {% set current_lang = DEFAULT_LANGUAGE %}
                 {% endif %}
-            </ul>
+                <span class="navbar-text text-white-50 me-2">{{ _('Language:') }} {{ get_language_label(current_lang) or current_lang }}</span>
+                <form method="post" action="/language" class="mb-0 d-inline">
+                    <input type="hidden" name="lang" value="{{ cycle_language(current_lang) }}">
+                    <input type="hidden" name="next" value="{{ request.url.path }}">
+                    <button class="btn btn-outline-light btn-sm" type="submit">{{ _('Change language') }}</button>
+                </form>
+                <ul class="navbar-nav ms-3 mb-0">
+                    {% if request.session.get('user_id') %}
+                    <li class="nav-item"><a class="nav-link" href="/logout">{{ _('Logout') }}</a></li>
+                    {% else %}
+                    <li class="nav-item"><a class="nav-link" href="/login">{{ _('Login') }}</a></li>
+                    {% endif %}
+                </ul>
+            </div>
         </div>
     </div>
 </nav>

--- a/test/web/test_web_app.py
+++ b/test/web/test_web_app.py
@@ -178,6 +178,7 @@ def test_change_language_updates_session():
             follow_redirects=False,
         )
         assert resp.status_code == 303
+        assert resp.headers["location"] == "/login"
         resp = client.get("/login")
         assert resp.status_code == 200
         assert "Change language" in resp.text

--- a/test/web/test_web_app.py
+++ b/test/web/test_web_app.py
@@ -165,3 +165,20 @@ def test_stats_requires_login():
     with TestClient(app) as client:
         resp = client.get("/stats")
         assert resp.status_code == 401
+
+
+def test_change_language_updates_session():
+    with TestClient(app) as client:
+        resp = client.get("/login")
+        assert resp.status_code == 200
+        assert "Сменить язык" in resp.text
+        resp = client.post(
+            "/language",
+            data={"lang": "en", "next": "/login"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 303
+        resp = client.get("/login")
+        assert resp.status_code == 200
+        assert "Change language" in resp.text
+        assert "Сменить язык" not in resp.text


### PR DESCRIPTION
## Summary
- update the web Auth middleware to apply the session locale and permit language switching requests
- expose a /language endpoint and navbar toggle that stores the selected language in the session
- cover the new behaviour with a FastAPI TestClient regression test and translation entries

## Testing
- uv run pytest test/web/test_web_app.py

------
https://chatgpt.com/codex/tasks/task_b_68d826246584832c8e4ae5c3effa210e