### PR TITLE
Ensure grouped media batches respect Telegram limits

### DIFF
--- a/telegram_auto_poster/utils/general.py
+++ b/telegram_auto_poster/utils/general.py
@@ -490,6 +490,67 @@ async def prepare_group_items(paths: List[str]) -> Tuple[List[dict], str]:
     return items, caption
 
 
+async def _send_media_group_with_retry(
+    bot: Bot, chat_id: int | str, media_group: list
+) -> None:
+    """Send a media group with retry logic for transient failures."""
+
+    max_retries = 3
+    last_error: Exception | None = None
+
+    for retry_count in range(1, max_retries + 1):
+        try:
+            await bot.send_media_group(
+                chat_id=chat_id,
+                media=media_group,
+                read_timeout=60,
+                write_timeout=60,
+            )
+            return
+        except (TimedOut, NetworkError) as exc:
+            last_error = exc
+            wait_time = 2**retry_count
+            logger.warning(
+                "Network error sending media group, retrying in {wait_time}s (attempt {retry}/{max_retries}): {error}",
+                wait_time=wait_time,
+                retry=retry_count,
+                max_retries=max_retries,
+                error=exc,
+            )
+            await stats.record_error(
+                "telegram",
+                f"Network error sending media group (retrying): {str(exc)}",
+            )
+            await asyncio.sleep(wait_time)
+        except BadRequest as exc:
+            logger.error("Bad request error when sending media group: {error}", error=exc)
+            await stats.record_error(
+                "telegram", f"Failed to send media group (bad request): {str(exc)}"
+            )
+            raise TelegramMediaError(
+                f"Failed to send media group (bad request): {str(exc)}"
+            ) from exc
+        except Exception as exc:  # noqa: BLE001 - we want to log unexpected errors
+            logger.error("Unexpected error sending media group: {error}", error=exc)
+            await stats.record_error(
+                "telegram", f"Unexpected error sending media group: {str(exc)}"
+            )
+            raise TelegramMediaError(
+                f"Unexpected error sending media group: {str(exc)}"
+            ) from exc
+
+    logger.error(
+        "Failed to send media group after {max_retries} retries", max_retries=max_retries
+    )
+    await stats.record_error(
+        "telegram",
+        f"Failed to send media group after {max_retries} retries: {str(last_error)}",
+    )
+    raise TelegramMediaError(
+        f"Failed to send media group after {max_retries} retries: {str(last_error)}"
+    )
+
+
 async def send_group_media(
     bot: Bot, chat_ids: Iterable[int | str] | int | str, items: List[dict], caption: str
 ) -> None:
@@ -498,6 +559,17 @@ async def send_group_media(
         chat_ids = [chat_ids]
 
     if not items:
+        return
+
+    if len(items) == 1:
+        item = items[0]
+        await send_media_to_telegram(
+            bot,
+            chat_ids,
+            item["temp_path"],
+            caption=caption,
+            supports_streaming=item.get("media_type") == "video",
+        )
         return
 
     for chat_id in chat_ids:
@@ -520,4 +592,5 @@ async def send_group_media(
                         caption=caption if is_first else None,
                     )
                 media_group.append(media)
-            await bot.send_media_group(chat_id=chat_id, media=media_group)
+
+            await _send_media_group_with_retry(bot, chat_id, media_group)

--- a/telegram_auto_poster/utils/general.py
+++ b/telegram_auto_poster/utils/general.py
@@ -496,34 +496,28 @@ async def send_group_media(
     """Send a list of prepared items to one or more chats as a group."""
     if isinstance(chat_ids, (int, str)):
         chat_ids = [chat_ids]
-    if len(items) >= 2:
-        for chat_id in chat_ids:
-            for i in range(0, len(items), 10):
-                chunk = items[i : i + 10]
-                media_group = []
-                for idx, it in enumerate(chunk):
-                    is_first = i == 0 and idx == 0 and bool(caption)
-                    fh = it["file_obj"]
-                    fh.seek(0)
-                    if it["media_type"] == "video":
-                        media = InputMediaVideo(
-                            fh,
-                            supports_streaming=True,
-                            caption=caption if is_first else None,
-                        )
-                    else:
-                        media = InputMediaPhoto(
-                            fh,
-                            caption=caption if is_first else None,
-                        )
-                    media_group.append(media)
-                await bot.send_media_group(chat_id=chat_id, media=media_group)
-    elif len(items) == 1:
-        it = items[0]
-        await send_media_to_telegram(
-            bot,
-            chat_ids,
-            it["temp_path"],
-            caption=caption or None,
-            supports_streaming=(it["media_type"] == "video"),
-        )
+
+    if not items:
+        return
+
+    for chat_id in chat_ids:
+        for i in range(0, len(items), 10):
+            chunk = items[i : i + 10]
+            media_group = []
+            for idx, it in enumerate(chunk):
+                is_first = i == 0 and idx == 0 and bool(caption)
+                fh = it["file_obj"]
+                fh.seek(0)
+                if it["media_type"] == "video":
+                    media = InputMediaVideo(
+                        fh,
+                        supports_streaming=True,
+                        caption=caption if is_first else None,
+                    )
+                else:
+                    media = InputMediaPhoto(
+                        fh,
+                        caption=caption if is_first else None,
+                    )
+                media_group.append(media)
+            await bot.send_media_group(chat_id=chat_id, media=media_group)

--- a/test/utils/test_general.py
+++ b/test/utils/test_general.py
@@ -1,3 +1,4 @@
+import io
 import os
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -11,6 +12,7 @@ from telegram_auto_poster.utils.general import (
     extract_filename,
     extract_paths_from_message,
     get_file_extension,
+    send_group_media,
 )
 from telegram_auto_poster.utils.stats import stats
 from telegram_auto_poster.utils.storage import storage
@@ -158,3 +160,68 @@ async def test_download_from_minio_missing_object_records_error_and_cleanup(monk
     assert len(unlink_calls) == 1
     assert unlink_calls[0].endswith(".jpg")
     storage.client.get_object.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_group_media_batches_respect_limit(mocker):
+    bot = SimpleNamespace(send_media_group=mocker.AsyncMock())
+    items = []
+    seek_spies = []
+
+    for idx in range(13):
+        fh = io.BytesIO(b"data")
+        seek_spies.append(mocker.spy(fh, "seek"))
+        items.append(
+            {
+                "file_name": f"file{idx}.jpg",
+                "media_type": "photo",
+                "file_prefix": "photos/",
+                "path": f"photos/file{idx}.jpg",
+                "temp_path": f"/tmp/file{idx}.jpg",
+                "file_obj": fh,
+                "meta": None,
+            }
+        )
+
+    await send_group_media(bot, 123, items, "Caption")
+
+    assert bot.send_media_group.await_count == 2
+    first_call = bot.send_media_group.await_args_list[0].kwargs
+    second_call = bot.send_media_group.await_args_list[1].kwargs
+
+    assert len(first_call["media"]) == 10
+    assert len(second_call["media"]) == 3
+
+    assert first_call["media"][0].caption == "Caption"
+    for media in first_call["media"][1:]:
+        assert media.caption is None
+    for media in second_call["media"]:
+        assert media.caption is None
+
+    for spy in seek_spies:
+        assert spy.call_args_list[0].args == (0,)
+
+
+@pytest.mark.asyncio
+async def test_send_group_media_single_item_grouped(mocker):
+    bot = SimpleNamespace(send_media_group=mocker.AsyncMock())
+    fh = io.BytesIO(b"data")
+    items = [
+        {
+            "file_name": "file.jpg",
+            "media_type": "photo",
+            "file_prefix": "photos/",
+            "path": "photos/file.jpg",
+            "temp_path": "/tmp/file.jpg",
+            "file_obj": fh,
+            "meta": None,
+        }
+    ]
+
+    await send_group_media(bot, 123, items, "Caption")
+
+    bot.send_media_group.assert_awaited_once()
+    sent_call = bot.send_media_group.await_args.kwargs
+    media = sent_call["media"]
+    assert len(media) == 1
+    assert media[0].caption == "Caption"


### PR DESCRIPTION
## Summary
- always send batch uploads via grouped media messages while chunking at Telegram's 10-item limit
- add regression tests covering grouped batch sending and single-item batches

## Testing
- uv run pytest test/utils/test_general.py

------
https://chatgpt.com/codex/tasks/task_b_68da6e9aef28832c83d65226f3d0fb2a