### PR TITLE
Add richer analytics to the dashboard

### DIFF
--- a/telegram_auto_poster/bot/callbacks.py
+++ b/telegram_auto_poster/bot/callbacks.py
@@ -358,6 +358,7 @@ async def push_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
         await send_group_media(
             context.bot, target_channels, media_items, caption_to_send
         )
+        await stats.record_post_published(len(target_channels))
 
         # Post-send bookkeeping: dedup, delete, stats, notify
         for item in media_items:

--- a/telegram_auto_poster/bot/commands.py
+++ b/telegram_auto_poster/bot/commands.py
@@ -247,6 +247,8 @@ async def ok_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
         await storage.delete_file(PHOTOS_PATH + "/" + object_name, BUCKET_MAIN)
         logger.info("Created new post!")
 
+        await stats.record_post_published(len(target_channels))
+
         # Record stats
         media_type = "photo" if ext.lower() in [".jpg", ".jpeg", ".png"] else "video"
         meta = await storage.get_submission_metadata(object_name)
@@ -526,6 +528,8 @@ async def post_scheduled_media_job(context: ContextTypes.DEFAULT_TYPE) -> None:
                         in [".mp4", ".avi", ".mov"]
                     ),
                 )
+
+                await stats.record_post_published(len(target_channels))
 
                 # Clean up
                 await storage.delete_file(file_path, BUCKET_MAIN)

--- a/telegram_auto_poster/utils/general.py
+++ b/telegram_auto_poster/utils/general.py
@@ -523,7 +523,9 @@ async def _send_media_group_with_retry(
             )
             await asyncio.sleep(wait_time)
         except BadRequest as exc:
-            logger.error("Bad request error when sending media group: {error}", error=exc)
+            logger.error(
+                "Bad request error when sending media group: {error}", error=exc
+            )
             await stats.record_error(
                 "telegram", f"Failed to send media group (bad request): {str(exc)}"
             )
@@ -540,7 +542,8 @@ async def _send_media_group_with_retry(
             ) from exc
 
     logger.error(
-        "Failed to send media group after {max_retries} retries", max_retries=max_retries
+        "Failed to send media group after {max_retries} retries",
+        max_retries=max_retries,
     )
     await stats.record_error(
         "telegram",

--- a/telegram_auto_poster/utils/stats.py
+++ b/telegram_auto_poster/utils/stats.py
@@ -27,6 +27,12 @@ class MediaStats:
 
     _instance: "MediaStats" | None = None
 
+    processing_histogram_bounds: tuple[float, ...]
+    """Upper bounds (seconds) for processing time histogram buckets."""
+
+    processing_histogram_labels: tuple[str, ...]
+    """Human friendly labels for :attr:`processing_histogram_bounds`."""
+
     def __new__(cls) -> "MediaStats":  # pragma: no cover - singleton
         """Create or return the singleton instance."""
         if cls._instance is None:
@@ -53,6 +59,14 @@ class MediaStats:
                 "client_reconnects",
                 "rate_limit_drops",
             ]
+            cls._instance.processing_histogram_bounds = (1.0, 2.0, 5.0, 10.0)
+            cls._instance.processing_histogram_labels = (
+                "<1s",
+                "1-2s",
+                "2-5s",
+                "5-10s",
+                "≥10s",
+            )
             try:  # Initialise counters immediately
                 loop = asyncio.get_running_loop()
                 loop.create_task(cls._instance._init())
@@ -97,6 +111,7 @@ class MediaStats:
         await self._increment("media_processed")
         await self._increment("media_processed", scope="total")
         await self._record_duration(f"{media_type}_processing", processing_time)
+        await self._record_processing_histogram(media_type, processing_time)
         if media_type == "photo":
             await self._increment("photos_processed")
             await self._increment("photos_processed", scope="total")
@@ -119,6 +134,15 @@ class MediaStats:
         await self.r.incrby(hour_key, count)
         if source:
             await self.r.zincrby(_redis_key("leaderboard", "approved"), count, source)
+
+    async def record_post_published(
+        self, count: int = 1, *, timestamp: datetime.datetime | None = None
+    ) -> None:
+        """Record that ``count`` posts were published to the target channels."""
+
+        ts = timestamp or now_utc()
+        day_key = ts.strftime("%Y-%m-%d")
+        await self.r.incrby(_redis_key("posts", day_key), count)
 
     async def record_rejected(
         self, media_type: str, filename: str | None = None, source: str | None = None
@@ -208,6 +232,23 @@ class MediaStats:
             stats[name] = int(value)
         return stats
 
+    async def get_daily_post_counts(self, days: int = 14) -> list[dict[str, int]]:
+        """Return the number of posts published per day for the last ``days`` days."""
+
+        today = now_utc().date()
+        start = today - datetime.timedelta(days=days - 1)
+        dates = [start + datetime.timedelta(days=i) for i in range(days)]
+        keys = [_redis_key("posts", d.strftime("%Y-%m-%d")) for d in dates]
+        if keys:
+            raw_values = await self.r.mget(*keys)
+        else:  # pragma: no cover - empty range safeguard
+            raw_values = []
+        results: list[dict[str, int]] = []
+        for date_obj, value in zip(dates, raw_values):
+            count = int(value) if value else 0
+            results.append({"date": date_obj.isoformat(), "count": count})
+        return results
+
     async def _avg(self, base: str) -> float:
         """Return the average duration recorded for ``base``."""
         total = await self.r.get(_redis_key("perf", f"{base}_total")) or 0
@@ -289,6 +330,58 @@ class MediaStats:
             "approved": appr_sorted,
             "rejected": rej_sorted,
         }
+
+    async def get_source_acceptance(
+        self, limit: int = 8
+    ) -> list[dict[str, float | int | str]]:
+        """Return per-source acceptance and rejection counts and rates."""
+
+        subs_key = _redis_key("leaderboard", "submissions")
+        appr_key = _redis_key("leaderboard", "approved")
+        rej_key = _redis_key("leaderboard", "rejected")
+        top_sources = await self.r.zrevrange(subs_key, 0, limit - 1, withscores=True)
+        if not top_sources:
+            return []
+        entries: list[dict[str, float | int | str]] = []
+        for raw_source, raw_submissions in top_sources:
+            source = raw_source.decode() if isinstance(raw_source, bytes) else raw_source
+            submissions = int(float(raw_submissions))
+            approved_raw = await self.r.zscore(appr_key, source)
+            rejected_raw = await self.r.zscore(rej_key, source)
+            approved = int(float(approved_raw or 0))
+            rejected = int(float(rejected_raw or 0))
+            decision_total = approved + rejected
+            acceptance = (
+                (approved / decision_total) * 100 if decision_total else 0.0
+            )
+            entries.append(
+                {
+                    "source": source,
+                    "submissions": submissions,
+                    "approved": approved,
+                    "rejected": rejected,
+                    "acceptance_rate": acceptance,
+                }
+            )
+        return entries
+
+    async def get_processing_histogram(self) -> dict[str, list[dict[str, float | int]]]:
+        """Return histogram buckets for photo and video processing durations."""
+
+        result: dict[str, list[dict[str, float | int]]] = {}
+        for media_type in ("photo", "video"):
+            key = _redis_key("hist", f"{media_type}_processing")
+            raw = await self.r.hgetall(key) or {}
+            processed: list[dict[str, float | int]] = []
+            for label in self.processing_histogram_labels:
+                value = raw.get(label)
+                if value is None and isinstance(raw, dict):
+                    # aiovalkey may return bytes keys/values
+                    value = raw.get(label.encode())
+                count = int(value) if value else 0
+                processed.append({"label": label, "count": count})
+            result[media_type] = processed
+        return result
 
     async def generate_stats_report(self, reset_daily: bool = True) -> str:
         """Return a formatted statistics report for admins."""
@@ -402,6 +495,23 @@ class MediaStats:
             await self.r.save()
         except Exception:  # pragma: no cover - best effort
             pass
+
+    async def _record_processing_histogram(
+        self, media_type: str, duration: float
+    ) -> None:
+        """Record ``duration`` in the histogram for ``media_type`` processing."""
+
+        bucket = self._processing_histogram_bucket(duration)
+        key = _redis_key("hist", f"{media_type}_processing")
+        await self.r.hincrby(key, bucket, 1)
+
+    def _processing_histogram_bucket(self, duration: float) -> str:
+        """Return the histogram label bucket for ``duration`` seconds."""
+
+        for idx, bound in enumerate(self.processing_histogram_bounds):
+            if duration < bound:
+                return self.processing_histogram_labels[idx]
+        return self.processing_histogram_labels[-1]
 
 
 stats = MediaStats()

--- a/telegram_auto_poster/utils/stats.py
+++ b/telegram_auto_poster/utils/stats.py
@@ -362,9 +362,7 @@ class MediaStats:
             approved = int(float(approved_scores[i] or 0))
             rejected = int(float(rejected_scores[i] or 0))
             decision_total = approved + rejected
-            acceptance = (
-                (approved / decision_total) * 100 if decision_total else 0.0
-            )
+            acceptance = (approved / decision_total) * 100 if decision_total else 0.0
             entries.append(
                 {
                     "source": source,

--- a/telegram_auto_poster/web/app.py
+++ b/telegram_auto_poster/web/app.py
@@ -86,7 +86,12 @@ class AuthMiddleware(BaseHTTPMiddleware):
         request.state.language = lang
         set_locale(lang)
         path = request.url.path
-        if path.startswith("/static") or path in {"/login", "/auth", "/logout", "/language"}:
+        if path.startswith("/static") or path in {
+            "/login",
+            "/auth",
+            "/logout",
+            "/language",
+        }:
             return await call_next(request)
         user_id = request.session.get("user_id")
         logger.debug(
@@ -553,7 +558,9 @@ async def change_language(
     """Persist the selected language in the session and redirect back."""
 
     if lang not in LANGUAGES:
-        return JSONResponse({"status": "error", "detail": "invalid language"}, status_code=400)
+        return JSONResponse(
+            {"status": "error", "detail": "invalid language"}, status_code=400
+        )
     request.session["language"] = lang
     set_locale(lang)
     target = _safe_redirect_target(next_url)

--- a/telegram_auto_poster/web/static/js/charts.js
+++ b/telegram_auto_poster/web/static/js/charts.js
@@ -217,14 +217,10 @@
         if (!labels.length) {
             return null;
         }
-        const photoCounts = labels.map((label) => {
-            const match = photoBuckets.find((entry) => entry.label === label);
-            return match ? Number(match.count) : 0;
-        });
-        const videoCounts = labels.map((label) => {
-            const match = videoBuckets.find((entry) => entry.label === label);
-            return match ? Number(match.count) : 0;
-        });
+        const photoMap = new Map(photoBuckets.map((entry) => [entry.label, entry.count]));
+        const videoMap = new Map(videoBuckets.map((entry) => [entry.label, entry.count]));
+        const photoCounts = labels.map((label) => Number(photoMap.get(label) || 0));
+        const videoCounts = labels.map((label) => Number(videoMap.get(label) || 0));
         return {
             type: 'bar',
             data: {

--- a/telegram_auto_poster/web/static/js/charts.js
+++ b/telegram_auto_poster/web/static/js/charts.js
@@ -11,7 +11,9 @@
         if (canvas) {
             const ctx = canvas.getContext('2d');
             const chartConfig = chartConfigBuilder(canvas.dataset);
-            new Chart(ctx, chartConfig);
+            if (chartConfig) {
+                new Chart(ctx, chartConfig);
+            }
         }
     };
 
@@ -150,6 +152,147 @@
             },
             options: {
                 responsive: true,
+            },
+        };
+    });
+
+    createChartFromCanvas('source-acceptance', (dataset) => {
+        const sourcesRaw = dataset.sources ? JSON.parse(dataset.sources) : [];
+        if (sourcesRaw.length === 0) {
+            return null;
+        }
+        const labels = sourcesRaw.map((entry) => entry.source);
+        const acceptanceRates = sourcesRaw.map((entry) => Number(entry.acceptance_rate || 0));
+        return {
+            type: 'bar',
+            data: {
+                labels,
+                datasets: [{
+                    label: 'Acceptance %',
+                    data: acceptanceRates,
+                    backgroundColor: '#0d6efd',
+                }],
+            },
+            options: {
+                indexAxis: 'y',
+                responsive: true,
+                scales: {
+                    x: {
+                        beginAtZero: true,
+                        max: 100,
+                    },
+                },
+                plugins: {
+                    tooltip: {
+                        callbacks: {
+                            afterBody: (items) => {
+                                if (!items.length) {
+                                    return [];
+                                }
+                                const idx = items[0].dataIndex;
+                                const entry = sourcesRaw[idx];
+                                return [
+                                    `Submissions: ${entry.submissions}`,
+                                    `Approved: ${entry.approved}`,
+                                    `Rejected: ${entry.rejected}`,
+                                ];
+                            },
+                        },
+                    },
+                    legend: {
+                        display: false,
+                    },
+                },
+            },
+        };
+    });
+
+    createChartFromCanvas('processing-histogram', (dataset) => {
+        const histogram = dataset.histogram ? JSON.parse(dataset.histogram) : {};
+        const photoBuckets = histogram.photo || [];
+        const videoBuckets = histogram.video || [];
+        const labels = photoBuckets.length
+            ? photoBuckets.map((entry) => entry.label)
+            : videoBuckets.map((entry) => entry.label);
+        if (!labels.length) {
+            return null;
+        }
+        const photoCounts = labels.map((label) => {
+            const match = photoBuckets.find((entry) => entry.label === label);
+            return match ? Number(match.count) : 0;
+        });
+        const videoCounts = labels.map((label) => {
+            const match = videoBuckets.find((entry) => entry.label === label);
+            return match ? Number(match.count) : 0;
+        });
+        return {
+            type: 'bar',
+            data: {
+                labels,
+                datasets: [
+                    {
+                        label: 'Photos',
+                        data: photoCounts,
+                        backgroundColor: '#0d6efd',
+                    },
+                    {
+                        label: 'Videos',
+                        data: videoCounts,
+                        backgroundColor: '#6610f2',
+                    },
+                ],
+            },
+            options: {
+                responsive: true,
+                scales: {
+                    y: {
+                        beginAtZero: true,
+                        ticks: {
+                            stepSize: 1,
+                            callback: (value) => (Number.isInteger(value) ? value : null),
+                        },
+                    },
+                },
+            },
+        };
+    });
+
+    createChartFromCanvas('daily-post-counts', (dataset) => {
+        const postsRaw = dataset.posts ? JSON.parse(dataset.posts) : [];
+        if (!postsRaw.length) {
+            return null;
+        }
+        const labels = postsRaw.map((entry) => entry.date);
+        const counts = postsRaw.map((entry) => Number(entry.count || 0));
+        return {
+            type: 'line',
+            data: {
+                labels,
+                datasets: [{
+                    label: 'Posts',
+                    data: counts,
+                    borderColor: '#198754',
+                    backgroundColor: 'rgba(25, 135, 84, 0.2)',
+                    tension: 0.3,
+                    fill: true,
+                }],
+            },
+            options: {
+                responsive: true,
+                scales: {
+                    y: {
+                        beginAtZero: true,
+                        ticks: {
+                            stepSize: 1,
+                            callback: (value) => (Number.isInteger(value) ? value : null),
+                        },
+                    },
+                },
+                plugins: {
+                    legend: {
+                        display: false,
+                    },
+                },
             },
         };
     });

--- a/telegram_auto_poster/web/templates/stats.html
+++ b/telegram_auto_poster/web/templates/stats.html
@@ -129,8 +129,51 @@
         </div>
     </div>
 </div>
+<div class="row mt-4">
+    <div class="col-md-6">
+        <div class="card mb-4">
+            <div class="card-header">
+                <h2>{{ _('Per-Source Acceptance Rate') }}</h2>
+            </div>
+            <div class="card-body">
+                <canvas
+                    id="source-acceptance"
+                    data-sources="{{ source_acceptance|tojson }}"
+                ></canvas>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-6">
+        <div class="card mb-4">
+            <div class="card-header">
+                <h2>{{ _('Processing Time Histogram') }}</h2>
+            </div>
+            <div class="card-body">
+                <canvas
+                    id="processing-histogram"
+                    data-histogram="{{ processing_histogram|tojson }}"
+                ></canvas>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="row mt-4">
+    <div class="col-12">
+        <div class="card mb-4">
+            <div class="card-header">
+                <h2>{{ _('Daily Posts') }}</h2>
+            </div>
+            <div class="card-body">
+                <canvas
+                    id="daily-post-counts"
+                    data-posts="{{ daily_post_counts|tojson }}"
+                ></canvas>
+            </div>
+        </div>
+    </div>
+</div>
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/charts.js?v5"></script>
+<script src="/static/js/charts.js?v6"></script>
 {% endblock %}

--- a/test/web/test_web_app.py
+++ b/test/web/test_web_app.py
@@ -157,6 +157,18 @@ def test_stats_endpoint(mocker, auth_client: TestClient):
         "telegram_auto_poster.web.app.stats.get_success_rate_24h",
         new=mocker.AsyncMock(return_value=0.0),
     )
+    mocker.patch(
+        "telegram_auto_poster.web.app.stats.get_source_acceptance",
+        new=mocker.AsyncMock(return_value=[]),
+    )
+    mocker.patch(
+        "telegram_auto_poster.web.app.stats.get_processing_histogram",
+        new=mocker.AsyncMock(return_value={"photo": [], "video": []}),
+    )
+    mocker.patch(
+        "telegram_auto_poster.web.app.stats.get_daily_post_counts",
+        new=mocker.AsyncMock(return_value=[]),
+    )
     resp = auth_client.get("/stats")
     assert resp.status_code == 200
 


### PR DESCRIPTION
## Summary
- track per-source acceptance, processing histograms, and daily post counts in Valkey-backed stats
- expose new metrics via the FastAPI dashboard view and updated charts
- record post publication counts throughout bot flows and refresh web tests

## Testing
- uv run pytest -n auto

------
https://chatgpt.com/codex/tasks/task_b_68dce8283cb4832ca7b73698c032375d