### PR TITLE
Fix language toggle by loading session middleware first

### DIFF
--- a/telegram_auto_poster/web/app.py
+++ b/telegram_auto_poster/web/app.py
@@ -108,10 +108,10 @@ class AuthMiddleware(BaseHTTPMiddleware):
 
 
 app = FastAPI(title="Telegram Autoposter Admin")
-app.add_middleware(AuthMiddleware)
 app.add_middleware(
     SessionMiddleware, secret_key=CONFIG.web.session_secret.get_secret_value()
 )
+app.add_middleware(AuthMiddleware)
 
 base_path = Path(__file__).parent
 templates = Jinja2Templates(directory=str(base_path / "templates"))


### PR DESCRIPTION
## Summary
- ensure the session middleware executes before the custom auth middleware so the language stored in the session is available during each request

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68dd49685cbc832cbb7685b4c08d5596