### PR TITLE
Enable live removal of processed posts

### DIFF
--- a/telegram_auto_poster/web/templates/_post_grid.html
+++ b/telegram_auto_poster/web/templates/_post_grid.html
@@ -13,7 +13,7 @@
         {% endif %}
         {% endfor %}
         <div class="mt-2 d-flex flex-wrap gap-1">
-            <form method="post" action="/action" data-bg="true" data-remove-target="{{ card_id }}">
+            <form method="post" action="/action" data-bg="true">
                 {% for media in p['items'] %}
                 <input type="hidden" name="paths" value="{{ media.path }}" />
                 {% endfor %}
@@ -21,7 +21,7 @@
                 <input type="hidden" name="origin" value="{{ origin }}" />
                 <button class="btn btn-sm btn-success" type="submit">{{ _('Send to batch!') }}</button>
             </form>
-            <form method="post" action="/action" data-bg="true" data-remove-target="{{ card_id }}">
+            <form method="post" action="/action" data-bg="true">
                 {% for media in p['items'] %}
                 <input type="hidden" name="paths" value="{{ media.path }}" />
                 {% endfor %}
@@ -29,7 +29,7 @@
                 <input type="hidden" name="origin" value="{{ origin }}" />
                 <button class="btn btn-sm btn-secondary" type="submit">{{ _('Schedule') }}</button>
             </form>
-            <form method="post" action="/action" data-bg="true" data-remove-target="{{ card_id }}">
+            <form method="post" action="/action" data-bg="true">
                 {% for media in p['items'] %}
                 <input type="hidden" name="paths" value="{{ media.path }}" />
                 {% endfor %}
@@ -41,7 +41,6 @@
                 method="post"
                 action="/action"
                 data-bg="true"
-                data-remove-target="{{ card_id }}"
             >
                 {% for media in p['items'] %}
                 <input type="hidden" name="paths" value="{{ media.path }}" />

--- a/telegram_auto_poster/web/templates/base.html
+++ b/telegram_auto_poster/web/templates/base.html
@@ -104,18 +104,15 @@ document.addEventListener('submit', function(e) {
         btn.textContent = '{{ _('Done') }}';
         btn.classList.add('btn-success');
       }
-      const targetId = form.dataset.removeTarget;
-      if (targetId) {
-        const card = document.getElementById(targetId);
-        if (card) {
-          const grid = card.closest('[id$="-grid"]');
-          card.remove();
-          if (grid) {
-            const container = grid.querySelector('[data-grid-container]');
-            const emptyMessage = grid.querySelector('[data-empty-message]');
-            if (container && emptyMessage && container.querySelectorAll('[data-card]').length === 0) {
-              emptyMessage.classList.remove('d-none');
-            }
+      const card = form.closest('[data-card]');
+      if (card) {
+        const grid = card.closest('[id$="-grid"]');
+        card.remove();
+        if (grid) {
+          const container = grid.querySelector('[data-grid-container]');
+          const emptyMessage = grid.querySelector('[data-empty-message]');
+          if (container && emptyMessage && container.querySelectorAll('[data-card]').length === 0) {
+            emptyMessage.classList.remove('d-none');
           }
         }
       }


### PR DESCRIPTION
## Summary
- add card identifiers and empty state placeholders to the shared post grid template
- enhance the background form handler to remove processed cards and reveal empty-state messaging without a manual refresh

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_b_68de406e7b50832c824cbb8a8980f1c1