### PR TITLE
Fix top-hours chart to render 24 hourly buckets (0–23)

### DIFF
--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -489,7 +489,15 @@ const StatsPage = () => {
                                   >
                                     <ComposedChart data={points}>
                                       <CartesianGrid vertical={false} />
-                                      <XAxis dataKey="label" minTickGap={24} />
+                                      <XAxis
+                                        dataKey="label"
+                                        minTickGap={graph.key === "top_hours" ? 8 : 24}
+                                        tickFormatter={(value) =>
+                                          graph.key === "top_hours" && typeof value === "number"
+                                            ? formatHourLabel(value)
+                                            : String(value)
+                                        }
+                                      />
                                       <YAxis
                                         allowDecimals={!graph.percentage}
                                         tickFormatter={(value) =>
@@ -498,7 +506,18 @@ const StatsPage = () => {
                                             : String(value)
                                         }
                                       />
-                                      <ChartTooltip content={<ChartTooltipContent />} />
+                                      <ChartTooltip
+                                        content={
+                                          <ChartTooltipContent
+                                            labelFormatter={(value) =>
+                                              graph.key === "top_hours" &&
+                                              typeof value === "number"
+                                                ? formatHourLabel(value)
+                                                : String(value)
+                                            }
+                                          />
+                                        }
+                                      />
                                       <ChartLegend content={<ChartLegendContent />} />
                                       {seriesWithColors.map((item) =>
                                         item.type === "bar" ? (

--- a/telegram_auto_poster/utils/channel_analytics.py
+++ b/telegram_auto_poster/utils/channel_analytics.py
@@ -82,6 +82,48 @@ def _format_graph_x(value: Any) -> tuple[str, str]:
     return str(value), str(value)
 
 
+def _to_hour_bucket(value: Any) -> int | None:
+    """Convert graph x-value into an hour bucket [0..23] when possible."""
+
+    if isinstance(value, (int, float)):
+        numeric = float(value)
+        if 0 <= numeric <= 23:
+            return int(numeric)
+        ts = numeric / 1000 if numeric > 10_000_000_000 else numeric
+        dt = datetime.datetime.fromtimestamp(ts, tz=datetime.UTC)
+        return dt.hour
+    return None
+
+
+def _normalize_top_hours_points(
+    points: list[dict[str, Any]], series_keys: Sequence[str]
+) -> list[dict[str, Any]]:
+    """Return exactly 24 hourly buckets for Telegram ``top_hours`` charts."""
+
+    buckets: list[dict[str, Any]] = []
+    for hour in range(24):
+        point: dict[str, Any] = {
+            "x": str(hour),
+            "label": hour,
+            "raw_x": hour,
+        }
+        for series_key in series_keys:
+            point[series_key] = 0
+        buckets.append(point)
+
+    for point in points:
+        hour = _to_hour_bucket(point.get("raw_x"))
+        if hour is None or hour < 0 or hour > 23:
+            continue
+        bucket = buckets[hour]
+        for series_key in series_keys:
+            value = point.get(series_key)
+            if isinstance(value, (int, float)):
+                bucket[series_key] += value
+
+    return buckets
+
+
 async def _resolve_graph(
     client: TelegramClient, graph: types.TypeStatsGraph
 ) -> types.TypeStatsGraph:
@@ -155,6 +197,9 @@ async def _serialize_graph(
         }
         for series_key in keyed_columns
     ]
+    if key == "top_hours":
+        points = _normalize_top_hours_points(points, [item["key"] for item in series])
+
     if not series or not points:
         return None
 

--- a/test/utils/test_channel_analytics.py
+++ b/test/utils/test_channel_analytics.py
@@ -121,6 +121,14 @@ async def test_refresh_channel_analytics_cache_serializes_broadcast_stats(
     assert payload["channels"][0]["summary_metrics"][0]["current"] == 1200.0
     assert payload["channels"][0]["ratio_metrics"][0]["percentage"] == pytest.approx(35.0)
     assert payload["channels"][0]["graphs"][0]["series"][0]["label"] == "Followers"
+    top_hours_graph = next(
+        graph for graph in payload["channels"][0]["graphs"] if graph["key"] == "top_hours"
+    )
+    assert len(top_hours_graph["points"]) == 24
+    assert top_hours_graph["points"][0]["label"] == 0
+    assert top_hours_graph["points"][-1]["label"] == 23
+    assert top_hours_graph["points"][0]["y0"] == 220
+    assert top_hours_graph["points"][0]["y1"] == 95
     assert payload["channels"][0]["recent_posts"][0]["link"] == "https://t.me/mychannel/101"
 
     cached = await get_cached_channel_analytics()


### PR DESCRIPTION
### Motivation
- The Telegram `top_hours` graph was serialized from timestamp-like x values and rendered with date labels (e.g. Jan 01) instead of a 0..23 hourly axis. This made the chart misleading for hourly distributions. 
- The UI needs exactly 24 integer hour buckets so the graph shows counts per hour-of-day and tooltip/x-axis labels as `HH:00`.

### Description
- Add `_to_hour_bucket` helper to convert incoming graph x-values (timestamps or numeric) to an hour-of-day bucket and `_normalize_top_hours_points` to produce exactly 24 buckets (0..23) and aggregate series values into those buckets in `telegram_auto_poster/utils/channel_analytics.py`.
- Apply normalization only for graphs with `key == "top_hours"` during `_serialize_graph` so other graphs are unchanged.
- Update frontend chart rendering in `frontend/src/pages/StatsPage.tsx` to format `top_hours` x-axis ticks and tooltip labels using `formatHourLabel` (`HH:00`) and to adjust `minTickGap` for the hourly chart.
- Extend `test/utils/test_channel_analytics.py` to assert that `top_hours` produces 24 points labeled `0..23` and checks aggregated values for the example series.

### Testing
- Ran frontend production build with `npm --prefix frontend run build`, which completed successfully. (success)
- Compiled Python sources with `python -m compileall telegram_auto_poster/utils/channel_analytics.py frontend/src/pages/StatsPage.tsx` to validate syntax. (success)
- Attempted to run `uv run pytest test/utils/test_channel_analytics.py` but it failed due to network/dependency fetch issues in the environment (package download tunnel error). (failed)
- Attempted `python -m pytest test/utils/test_channel_analytics.py` but it failed locally due to missing test dependency `fakeredis`. (failed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b7c0b13fd0832fb4cff546a7aca390)