### PR TITLE
🧹 [Code Health Improvement] Refactor _add_media_hash parameters into a Dataclass

### DIFF
--- a/telegram_auto_poster/bot/callbacks.py
+++ b/telegram_auto_poster/bot/callbacks.py
@@ -2,6 +2,7 @@
 
 import datetime
 import os
+from dataclasses import dataclass
 from typing import Any
 
 from loguru import logger
@@ -114,42 +115,45 @@ def _compute_media_hash(temp_path: str, media_type: str) -> str | None:
     )
 
 
-async def _add_media_hash(
-    file_name: str,
-    media_type: str,
-    file_prefix: str,
-    temp_path: str | None,
-    metadata: dict[str, Any] | None,
-    context_name: str,
-) -> str | None:
-    """Ensure ``file_name`` is present in the deduplication corpus."""
+@dataclass
+class MediaContext:
+    file_name: str
+    media_type: str
+    file_prefix: str
+    context_name: str
+    temp_path: str | None = None
+    metadata: dict[str, Any] | None = None
+
+
+async def _add_media_hash(ctx: MediaContext) -> str | None:
+    """Ensure ``ctx.file_name`` is present in the deduplication corpus."""
     media_hash = None
     try:
-        meta = metadata or await storage.get_submission_metadata(file_name)
+        meta = ctx.metadata or await storage.get_submission_metadata(ctx.file_name)
         if meta and meta.get("hash"):
             media_hash = meta.get("hash")
         else:
-            if temp_path is None:
-                temp_path, _ = await download_from_minio(
-                    file_prefix + file_name, BUCKET_MAIN
+            if ctx.temp_path is None:
+                ctx.temp_path, _ = await download_from_minio(
+                    ctx.file_prefix + ctx.file_name, BUCKET_MAIN
                 )
                 temp_created = True
             else:
                 temp_created = False
             try:
-                media_hash = _compute_media_hash(temp_path, media_type)
+                media_hash = _compute_media_hash(ctx.temp_path, ctx.media_type)
             finally:
                 if temp_created:
-                    cleanup_temp_file(temp_path)
+                    cleanup_temp_file(ctx.temp_path)
         if media_hash:
             add_approved_hash(media_hash)
     except MinioError as _e:
         logger.warning(
-            f"MinIO error while adding approved hash for {file_name} in {context_name}: {_e}"
+            f"MinIO error while adding approved hash for {ctx.file_name} in {ctx.context_name}: {_e}"
         )
     except Exception as _e:
         logger.warning(
-            f"Unexpected error when adding approved hash for {file_name} in {context_name}: {_e}"
+            f"Unexpected error when adding approved hash for {ctx.file_name} in {ctx.context_name}: {_e}"
         )
     return media_hash
 
@@ -207,12 +211,12 @@ async def schedule_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) 
             # 2. Add to approved dedup corpus (use stored hash or compute)
             media_type = "photo" if file_path.startswith(f"{PHOTOS_PATH}/") else "video"
             await _add_media_hash(
-                file_name,
-                media_type,
-                file_prefix,
-                None,
-                None,
-                "schedule_callback",
+                MediaContext(
+                    file_name=file_name,
+                    media_type=media_type,
+                    file_prefix=file_prefix,
+                    context_name="schedule_callback",
+                )
             )
 
             # 3. Move file in MinIO
@@ -287,12 +291,14 @@ async def ok_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
                 target_prefix = PHOTOS_PATH if media_type == "photo" else VIDEOS_PATH
                 src_meta = await storage.get_submission_metadata(file_name)
                 media_hash = await _add_media_hash(
-                    file_name,
-                    media_type,
-                    file_prefix,
-                    temp_path,
-                    src_meta,
-                    "ok_callback(batch)",
+                    MediaContext(
+                        file_name=file_name,
+                        media_type=media_type,
+                        file_prefix=file_prefix,
+                        temp_path=temp_path,
+                        metadata=src_meta,
+                        context_name="ok_callback(batch)",
+                    )
                 )
                 await storage.upload_file(
                     temp_path,
@@ -382,12 +388,14 @@ async def push_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
             user_metadata = item["meta"]
             try:
                 await _add_media_hash(
-                    file_name,
-                    media_type,
-                    file_prefix,
-                    temp_path,
-                    user_metadata,
-                    "push_callback",
+                    MediaContext(
+                        file_name=file_name,
+                        media_type=media_type,
+                        file_prefix=file_prefix,
+                        temp_path=temp_path,
+                        metadata=user_metadata,
+                        context_name="push_callback",
+                    )
                 )
 
                 # Delete from MinIO

--- a/telegram_auto_poster/client/client.py
+++ b/telegram_auto_poster/client/client.py
@@ -167,8 +167,7 @@ class TelegramMemeClient:
                     if request_id is not None:
                         await mark_channel_analytics_refresh_completed(request_id)
                     next_refresh_at = (
-                        time.monotonic()
-                        + CHANNEL_ANALYTICS_REFRESH_THRESHOLD_SECONDS
+                        time.monotonic() + CHANNEL_ANALYTICS_REFRESH_THRESHOLD_SECONDS
                     )
             except asyncio.CancelledError:  # pragma: no cover - task cancellation
                 raise

--- a/telegram_auto_poster/utils/jobs.py
+++ b/telegram_auto_poster/utils/jobs.py
@@ -949,7 +949,9 @@ async def _run_rebuild_dedup_hashes(context: JobRunContext) -> None:
     """Backfill the approved deduplication corpus from stored media objects."""
 
     objects = await storage.list_files(BUCKET_MAIN)
-    media_objects = [path for path in objects if _is_image_path(path) or _is_video_path(path)]
+    media_objects = [
+        path for path in objects if _is_image_path(path) or _is_video_path(path)
+    ]
     await context.replace_stats(
         {
             "objects_total": len(objects),
@@ -992,9 +994,13 @@ async def _run_rebuild_dedup_hashes(context: JobRunContext) -> None:
                 continue
 
             if _is_image_path(path):
-                media_hash = await asyncio.to_thread(calculate_image_hash, temp_path) or ""
+                media_hash = (
+                    await asyncio.to_thread(calculate_image_hash, temp_path) or ""
+                )
             elif _is_video_path(path):
-                media_hash = await asyncio.to_thread(calculate_video_hash, temp_path) or ""
+                media_hash = (
+                    await asyncio.to_thread(calculate_video_hash, temp_path) or ""
+                )
             else:
                 await context.increment("objects_skipped")
                 continue
@@ -1046,7 +1052,9 @@ async def _run_refresh_channel_analytics(context: JobRunContext) -> None:
             "channels_with_errors": 0,
         }
     )
-    await context.set_status_detail("Waiting for the Telethon client to refresh analytics")
+    await context.set_status_detail(
+        "Waiting for the Telethon client to refresh analytics"
+    )
 
     timeout_seconds = 30
     for waited in range(timeout_seconds + 1):

--- a/telegram_auto_poster/web/app.py
+++ b/telegram_auto_poster/web/app.py
@@ -666,7 +666,9 @@ async def _get_cached_posts_summary_groups() -> list[dict[str, object]] | None:
     return None
 
 
-async def _store_cached_posts_summary_groups(groups: Sequence[dict[str, object]]) -> None:
+async def _store_cached_posts_summary_groups(
+    groups: Sequence[dict[str, object]],
+) -> None:
     """Persist summary groups for reuse across requests."""
 
     try:
@@ -1359,9 +1361,9 @@ async def _send_batch_now(request: Request) -> dict[str, object]:
     for post in posts:
         all_paths.extend(
             [
-            item["path"]
-            for item in post["items"]
-            if isinstance(item, dict) and isinstance(item.get("path"), str)
+                item["path"]
+                for item in post["items"]
+                if isinstance(item, dict) and isinstance(item.get("path"), str)
             ]
         )
 
@@ -1903,7 +1905,9 @@ async def api_suggestions(page: int = 1, sort: str = "newest") -> JSONResponse:
     sorted_suggestions = _sort_posts_groups(suggestions, sanitized_sort)
     count = len(sorted_suggestions)
     page, total_pages, offset = _paginate(count, page, ITEMS_PER_PAGE)
-    items = await _hydrate_post_groups(sorted_suggestions[offset : offset + ITEMS_PER_PAGE])
+    items = await _hydrate_post_groups(
+        sorted_suggestions[offset : offset + ITEMS_PER_PAGE]
+    )
     return JSONResponse(
         {
             "items": items,
@@ -1942,13 +1946,16 @@ async def api_posts(
             if isinstance(source_name, str) and source_name
         }
     )
-    filtered_posts = _sort_posts_groups(_filter_posts_groups(
-        posts,
-        query=normalized_query,
-        kind=sanitized_kind,
-        layout=sanitized_layout,
-        source=normalized_source,
-    ), sanitized_sort)
+    filtered_posts = _sort_posts_groups(
+        _filter_posts_groups(
+            posts,
+            query=normalized_query,
+            kind=sanitized_kind,
+            layout=sanitized_layout,
+            source=normalized_source,
+        ),
+        sanitized_sort,
+    )
     count = len(filtered_posts)
     page, total_pages, offset = _paginate(count, page, ITEMS_PER_PAGE)
     items = await _hydrate_post_groups(filtered_posts[offset : offset + ITEMS_PER_PAGE])


### PR DESCRIPTION
🎯 What: Refactored `_add_media_hash` in `telegram_auto_poster/bot/callbacks.py` to use a `MediaContext` dataclass instead of accepting 6 individual parameters.

💡 Why: `_add_media_hash` previously had 6 parameters, which is a code health issue (too many arguments). Moving these arguments into a strongly typed `MediaContext` dataclass improves readability, groups related data logically, and sets up a pattern making it easier to add further properties if needed without modifying the function signature repeatedly.

✅ Verification: I ran `pytest test/` and all 239 tests passed without issue. I also ran `ruff format` and `ruff check --fix`.

✨ Result: A cleaner `_add_media_hash` signature and callsites, which is easier to maintain.

---
*PR created automatically by Jules for task [2930293605009144361](https://jules.google.com/task/2930293605009144361) started by @ooodnakov*