### PR TITLE
🧹 Refactor store_submission_metadata to use a dataclass

### DIFF
--- a/telegram_auto_poster/bot/handlers.py
+++ b/telegram_auto_poster/bot/handlers.py
@@ -37,7 +37,7 @@ from telegram_auto_poster.utils.general import (
 )
 from telegram_auto_poster.utils.i18n import _, resolve_locale, set_locale
 from telegram_auto_poster.utils.stats import stats
-from telegram_auto_poster.utils.storage import storage
+from telegram_auto_poster.utils.storage import storage, SubmissionMetadata
 from telegram_auto_poster.utils.timezone import now_utc
 from telegram_auto_poster.utils.ui import approval_keyboard
 
@@ -328,20 +328,22 @@ async def _send_to_review(
     if user_metadata:
         await storage.store_submission_metadata(
             processed_name,
-            user_metadata.get("user_id"),
-            user_metadata.get("chat_id"),
-            user_metadata.get("media_type"),
-            user_metadata.get("message_id"),
-            media_hash=media_hash,
-            group_id=user_metadata.get("group_id"),
-            caption=caption,
-            source=user_metadata.get("source"),
-            ocr_text=ocr_text,
-            ocr_status=ocr_status,
-            ocr_error=ocr_error,
-            ocr_checked_at=ocr_checked_at,
-            ocr_duration_seconds=ocr_duration_seconds,
-            ocr_languages=ocr_languages,
+            SubmissionMetadata(
+                user_id=user_metadata.get("user_id"),
+                chat_id=user_metadata.get("chat_id"),
+                media_type=user_metadata.get("media_type"),
+                message_id=user_metadata.get("message_id"),
+                media_hash=media_hash,
+                group_id=user_metadata.get("group_id"),
+                caption=caption,
+                source=user_metadata.get("source"),
+                ocr_text=ocr_text,
+                ocr_status=ocr_status,
+                ocr_error=ocr_error,
+                ocr_checked_at=ocr_checked_at,
+                ocr_duration_seconds=ocr_duration_seconds,
+                ocr_languages=ocr_languages,
+            ),
         )
     elif media_type == "photo":
         await storage.update_submission_metadata(

--- a/telegram_auto_poster/utils/storage.py
+++ b/telegram_auto_poster/utils/storage.py
@@ -7,6 +7,7 @@ import time
 from datetime import timedelta
 from inspect import iscoroutinefunction
 from typing import Mapping
+from dataclasses import dataclass
 from unittest.mock import MagicMock
 from urllib.parse import urlparse
 
@@ -25,6 +26,24 @@ from telegram_auto_poster.config import (
 )
 from telegram_auto_poster.utils.db import _redis_key, get_async_redis_client
 from telegram_auto_poster.utils.timezone import now_utc
+
+
+@dataclass
+class SubmissionMetadata:
+    user_id: int | None = None
+    chat_id: int | None = None
+    media_type: str | None = None
+    message_id: int | None = None
+    media_hash: str | None = None
+    group_id: str | None = None
+    caption: str | None = None
+    source: str | None = None
+    ocr_text: str | None = None
+    ocr_status: str | None = None
+    ocr_error: str | None = None
+    ocr_checked_at: str | None = None
+    ocr_duration_seconds: float | None = None
+    ocr_languages: str | None = None
 
 
 def _minio_connection_params() -> tuple[str, bool, str, str, str]:
@@ -219,20 +238,7 @@ class MinioStorage:
     async def store_submission_metadata(
         self,
         object_name: str,
-        user_id: int | None = None,
-        chat_id: int | None = None,
-        media_type: str | None = None,
-        message_id: int | None = None,
-        media_hash: str | None = None,
-        group_id: str | None = None,
-        caption: str | None = None,
-        source: str | None = None,
-        ocr_text: str | None = None,
-        ocr_status: str | None = None,
-        ocr_error: str | None = None,
-        ocr_checked_at: str | None = None,
-        ocr_duration_seconds: float | None = None,
-        ocr_languages: str | None = None,
+        metadata: SubmissionMetadata,
     ) -> None:
         """Store information about who submitted a particular media object.
 
@@ -241,34 +247,26 @@ class MinioStorage:
 
         Args:
             object_name: Name of the object in MinIO.
-            user_id: The Telegram ``user_id`` of the submitter.
-            chat_id: The Telegram ``chat_id`` where the media was submitted.
-            media_type: Type of media (``'photo'`` or ``'video'``).
-            message_id: Optional Telegram ``message_id`` of the original
-                submission.
-            media_hash: Optional hash used for deduplication.
-            group_id: Optional identifier for media groups/albums.
-            caption: Optional caption suggestion.
-            source: Optional identifier of the originating channel or user.
+            metadata: SubmissionMetadata dataclass instance.
 
         """
         meta: dict[str, object] = {
-            "user_id": user_id,
-            "chat_id": chat_id,
-            "media_type": media_type,
+            "user_id": metadata.user_id,
+            "chat_id": metadata.chat_id,
+            "media_type": metadata.media_type,
             "timestamp": now_utc().isoformat(),
             "notified": False,
-            "message_id": message_id,
-            "hash": media_hash,
-            "group_id": group_id,
-            "caption": caption,
-            "source": source,
-            "ocr_text": ocr_text,
-            "ocr_status": ocr_status,
-            "ocr_error": ocr_error,
-            "ocr_checked_at": ocr_checked_at,
-            "ocr_duration_seconds": ocr_duration_seconds,
-            "ocr_languages": ocr_languages,
+            "message_id": metadata.message_id,
+            "hash": metadata.media_hash,
+            "group_id": metadata.group_id,
+            "caption": metadata.caption,
+            "source": metadata.source,
+            "ocr_text": metadata.ocr_text,
+            "ocr_status": metadata.ocr_status,
+            "ocr_error": metadata.ocr_error,
+            "ocr_checked_at": metadata.ocr_checked_at,
+            "ocr_duration_seconds": metadata.ocr_duration_seconds,
+            "ocr_languages": metadata.ocr_languages,
         }
         meta["search_text"] = build_submission_search_text(object_name, meta)
         meta["search_text_updated_at"] = now_utc().isoformat()
@@ -284,12 +282,12 @@ class MinioStorage:
         logger.debug(
             "Stored metadata for {}: user_id={}, chat_id={}, message_id={}, group_id={}, caption={}, source={}".format(
                 object_name,
-                user_id,
-                chat_id,
-                message_id,
-                group_id,
-                caption,
-                source,
+                metadata.user_id,
+                metadata.chat_id,
+                metadata.message_id,
+                metadata.group_id,
+                metadata.caption,
+                metadata.source,
             )
         )
 
@@ -577,13 +575,15 @@ class MinioStorage:
             ):
                 await self.store_submission_metadata(
                     object_name,
-                    user_id,
-                    chat_id,
-                    media_type,
-                    message_id,
-                    media_hash,
-                    group_id,
-                    source=source,
+                    SubmissionMetadata(
+                        user_id=user_id,
+                        chat_id=chat_id,
+                        media_type=media_type,
+                        message_id=message_id,
+                        media_hash=media_hash,
+                        group_id=group_id,
+                        source=source,
+                    ),
                 )
 
             duration = time.time() - start_time

--- a/test/utils/test_storage.py
+++ b/test/utils/test_storage.py
@@ -1,3 +1,4 @@
+from telegram_auto_poster.utils.storage import SubmissionMetadata
 import pytest
 from miniopy_async.error import MinioException
 from pytest_mock import MockerFixture
@@ -179,13 +180,15 @@ async def test_store_and_get_submission_metadata(storage):
     """Test storing and retrieving submission metadata."""
     await storage.store_submission_metadata(
         "obj1",
-        123,
-        456,
-        "photo",
-        message_id=789,
-        media_hash="hash1",
-        group_id="g1",
-        source="src1",
+        SubmissionMetadata(
+            user_id=123,
+            chat_id=456,
+            media_type="photo",
+            message_id=789,
+            media_hash="hash1",
+            group_id="g1",
+            source="src1",
+        ),
     )
     meta = await storage.get_submission_metadata("obj1")
     assert meta["user_id"] == 123
@@ -198,7 +201,7 @@ async def test_store_and_get_submission_metadata(storage):
 async def test_get_submission_metadata_normalizes_prefix(storage):
     """Return metadata when only the basename is provided."""
     object_name = f"{PHOTOS_PATH}/obj3"
-    await storage.store_submission_metadata(object_name, 1, 2, "photo")
+    await storage.store_submission_metadata(object_name, SubmissionMetadata(user_id=1, chat_id=2, media_type="photo"))
     meta = await storage.get_submission_metadata("obj3")
     assert meta is not None
 
@@ -210,13 +213,15 @@ async def test_get_submission_metadata_from_redis(
     """Metadata is retrieved from Redis when not in memory."""
     await storage.store_submission_metadata(
         "obj_redis",
-        111,
-        222,
-        "photo",
-        message_id=333,
-        media_hash="hash2",
-        group_id="g2",
-        source="src2",
+        SubmissionMetadata(
+            user_id=111,
+            chat_id=222,
+            media_type="photo",
+            message_id=333,
+            media_hash="hash2",
+            group_id="g2",
+            source="src2",
+        ),
     )
     # Clear in-memory cache to force Redis lookup
     storage.submission_metadata = {}
@@ -232,14 +237,16 @@ async def test_submission_metadata_round_trip_includes_caption_and_source(storag
     """Round-trip Redis serialization should preserve caption and source."""
     await storage.store_submission_metadata(
         "obj_full",
-        321,
-        654,
-        "photo",
-        message_id=987,
-        media_hash="hash-full",
-        group_id="group-full",
-        caption="hello world",
-        source="source-full",
+        SubmissionMetadata(
+            user_id=321,
+            chat_id=654,
+            media_type="photo",
+            message_id=987,
+            media_hash="hash-full",
+            group_id="group-full",
+            caption="hello world",
+            source="source-full",
+        ),
     )
 
     storage.submission_metadata = {}
@@ -258,11 +265,13 @@ async def test_update_submission_metadata_preserves_caption_and_source(storage):
     """Updating unrelated fields must not remove caption/source."""
     await storage.store_submission_metadata(
         "obj_update",
-        100,
-        200,
-        "photo",
-        caption="keep me",
-        source="keep source",
+        SubmissionMetadata(
+            user_id=100,
+            chat_id=200,
+            media_type="photo",
+            caption="keep me",
+            source="keep source",
+        ),
     )
 
     updated = await storage.update_submission_metadata(
@@ -280,11 +289,13 @@ async def test_update_submission_metadata_resolves_prefixed_key(storage):
 
     await storage.store_submission_metadata(
         f"{PHOTOS_PATH}/batch_obj.jpg",
-        100,
-        200,
-        "photo",
-        caption="keep me",
-        source="keep source",
+        SubmissionMetadata(
+            user_id=100,
+            chat_id=200,
+            media_type="photo",
+            caption="keep me",
+            source="keep source",
+        ),
     )
 
     updated = await storage.update_submission_metadata(
@@ -305,11 +316,13 @@ async def test_refresh_submission_search_text_rebuilds_cached_value(storage):
 
     await storage.store_submission_metadata(
         "ocr_item.jpg",
-        1,
-        2,
-        "photo",
-        caption="hello",
-        source="@source",
+        SubmissionMetadata(
+            user_id=1,
+            chat_id=2,
+            media_type="photo",
+            caption="hello",
+            source="@source",
+        ),
     )
     await storage.update_submission_metadata("ocr_item.jpg", ocr_text="top text")
     await storage.update_submission_metadata("ocr_item.jpg", search_text="")
@@ -332,7 +345,7 @@ async def test_get_submission_metadata_missing(storage, mock_minio_client):
 @pytest.mark.asyncio
 async def test_mark_notified(storage, mock_redis_client):
     """Test marking a submission as notified."""
-    await storage.store_submission_metadata("obj1", 123, 456, "photo")
+    await storage.store_submission_metadata("obj1", SubmissionMetadata(user_id=123, chat_id=456, media_type="photo"))
     meta = await storage.get_submission_metadata("obj1")
     assert meta["notified"] is False
     await storage.mark_notified("obj1")


### PR DESCRIPTION
🎯 **What:** Introduced a `SubmissionMetadata` dataclass in `telegram_auto_poster/utils/storage.py` and refactored `store_submission_metadata` to use this new dataclass instead of taking 16 individual arguments. Updated all callers (including tests) to pass the new dataclass instance.

💡 **Why:** Using a parameter object simplifies the function signature, improves readability, and makes future enhancements (like adding more metadata fields) less disruptive and easier to maintain.

✅ **Verification:** Ran `pytest test/utils/test_storage.py` to ensure all tests passed. Ran all tests using `python -m pytest test/` and verified that they successfully completed. Removed the temporary Python scratchpad files left from earlier iterations to maintain a clean codebase.

✨ **Result:** A cleaner, more maintainable API for storing submission metadata without any regression in functionality.

---
*PR created automatically by Jules for task [16177155808344821521](https://jules.google.com/task/16177155808344821521) started by @ooodnakov*