### PR TITLE
🧪 [testing improvement] Add unit tests for build_submission_search_text

### DIFF
--- a/telegram_auto_poster/client/client.py
+++ b/telegram_auto_poster/client/client.py
@@ -167,8 +167,7 @@ class TelegramMemeClient:
                     if request_id is not None:
                         await mark_channel_analytics_refresh_completed(request_id)
                     next_refresh_at = (
-                        time.monotonic()
-                        + CHANNEL_ANALYTICS_REFRESH_THRESHOLD_SECONDS
+                        time.monotonic() + CHANNEL_ANALYTICS_REFRESH_THRESHOLD_SECONDS
                     )
             except asyncio.CancelledError:  # pragma: no cover - task cancellation
                 raise

--- a/telegram_auto_poster/utils/jobs.py
+++ b/telegram_auto_poster/utils/jobs.py
@@ -949,7 +949,9 @@ async def _run_rebuild_dedup_hashes(context: JobRunContext) -> None:
     """Backfill the approved deduplication corpus from stored media objects."""
 
     objects = await storage.list_files(BUCKET_MAIN)
-    media_objects = [path for path in objects if _is_image_path(path) or _is_video_path(path)]
+    media_objects = [
+        path for path in objects if _is_image_path(path) or _is_video_path(path)
+    ]
     await context.replace_stats(
         {
             "objects_total": len(objects),
@@ -992,9 +994,13 @@ async def _run_rebuild_dedup_hashes(context: JobRunContext) -> None:
                 continue
 
             if _is_image_path(path):
-                media_hash = await asyncio.to_thread(calculate_image_hash, temp_path) or ""
+                media_hash = (
+                    await asyncio.to_thread(calculate_image_hash, temp_path) or ""
+                )
             elif _is_video_path(path):
-                media_hash = await asyncio.to_thread(calculate_video_hash, temp_path) or ""
+                media_hash = (
+                    await asyncio.to_thread(calculate_video_hash, temp_path) or ""
+                )
             else:
                 await context.increment("objects_skipped")
                 continue
@@ -1046,7 +1052,9 @@ async def _run_refresh_channel_analytics(context: JobRunContext) -> None:
             "channels_with_errors": 0,
         }
     )
-    await context.set_status_detail("Waiting for the Telethon client to refresh analytics")
+    await context.set_status_detail(
+        "Waiting for the Telethon client to refresh analytics"
+    )
 
     timeout_seconds = 30
     for waited in range(timeout_seconds + 1):

--- a/telegram_auto_poster/web/app.py
+++ b/telegram_auto_poster/web/app.py
@@ -666,7 +666,9 @@ async def _get_cached_posts_summary_groups() -> list[dict[str, object]] | None:
     return None
 
 
-async def _store_cached_posts_summary_groups(groups: Sequence[dict[str, object]]) -> None:
+async def _store_cached_posts_summary_groups(
+    groups: Sequence[dict[str, object]],
+) -> None:
     """Persist summary groups for reuse across requests."""
 
     try:
@@ -1359,9 +1361,9 @@ async def _send_batch_now(request: Request) -> dict[str, object]:
     for post in posts:
         all_paths.extend(
             [
-            item["path"]
-            for item in post["items"]
-            if isinstance(item, dict) and isinstance(item.get("path"), str)
+                item["path"]
+                for item in post["items"]
+                if isinstance(item, dict) and isinstance(item.get("path"), str)
             ]
         )
 
@@ -1903,7 +1905,9 @@ async def api_suggestions(page: int = 1, sort: str = "newest") -> JSONResponse:
     sorted_suggestions = _sort_posts_groups(suggestions, sanitized_sort)
     count = len(sorted_suggestions)
     page, total_pages, offset = _paginate(count, page, ITEMS_PER_PAGE)
-    items = await _hydrate_post_groups(sorted_suggestions[offset : offset + ITEMS_PER_PAGE])
+    items = await _hydrate_post_groups(
+        sorted_suggestions[offset : offset + ITEMS_PER_PAGE]
+    )
     return JSONResponse(
         {
             "items": items,
@@ -1942,13 +1946,16 @@ async def api_posts(
             if isinstance(source_name, str) and source_name
         }
     )
-    filtered_posts = _sort_posts_groups(_filter_posts_groups(
-        posts,
-        query=normalized_query,
-        kind=sanitized_kind,
-        layout=sanitized_layout,
-        source=normalized_source,
-    ), sanitized_sort)
+    filtered_posts = _sort_posts_groups(
+        _filter_posts_groups(
+            posts,
+            query=normalized_query,
+            kind=sanitized_kind,
+            layout=sanitized_layout,
+            source=normalized_source,
+        ),
+        sanitized_sort,
+    )
     count = len(filtered_posts)
     page, total_pages, offset = _paginate(count, page, ITEMS_PER_PAGE)
     items = await _hydrate_post_groups(filtered_posts[offset : offset + ITEMS_PER_PAGE])

--- a/test/utils/test_storage.py
+++ b/test/utils/test_storage.py
@@ -503,3 +503,37 @@ async def test_count_files_uses_cache(storage, mock_minio_client, mock_redis_cli
     assert await storage.count_files(BUCKET_MAIN) == 2
     assert await storage.count_files(BUCKET_MAIN, prefix="a") == 1
     mock_minio_client.list_objects.assert_not_called()
+
+
+def test_build_submission_search_text_no_meta():
+    from telegram_auto_poster.utils.storage import build_submission_search_text
+
+    assert build_submission_search_text("my_file.jpg") == "my_file.jpg"
+
+
+def test_build_submission_search_text_full():
+    from telegram_auto_poster.utils.storage import build_submission_search_text
+
+    meta = {
+        "caption": "A cool picture",
+        "source": "Reddit",
+        "ocr_text": "Some text on image",
+    }
+    assert (
+        build_submission_search_text("my_file.jpg", meta)
+        == "my_file.jpg a cool picture reddit some text on image"
+    )
+
+
+def test_build_submission_search_text_normalization_and_deduplication():
+    from telegram_auto_poster.utils.storage import build_submission_search_text
+
+    meta = {"caption": "  My_file.jpg  ", "source": "Reddit", "ocr_text": "Reddit"}
+    # "my_file.jpg" is duplicate, "reddit" is duplicate
+    assert build_submission_search_text("my_file.jpg", meta) == "my_file.jpg reddit"
+
+
+def test_build_submission_search_text_with_path():
+    from telegram_auto_poster.utils.storage import build_submission_search_text
+
+    assert build_submission_search_text("photos/123/my_file.jpg") == "my_file.jpg"


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of unit tests for the `build_submission_search_text` function in `telegram_auto_poster/utils/storage.py`, which is responsible for normalizing and deduplicating string attributes to be cached for searching functionality.
📊 **Coverage:** The function is now fully covered, including the happy path (all metadata available), the absence of metadata (using just object basename), and specific normalizations like deduplication, lowercase conversion, and whitespaces trimming.
✨ **Result:** Test coverage for this file is improved and specific logic preventing duplicated terms in search strings is asserted and preserved for future refactors.

---
*PR created automatically by Jules for task [9282788543015935479](https://jules.google.com/task/9282788543015935479) started by @ooodnakov*