### PR TITLE
🧪 [testing improvement] Add internal state test for add_scheduled_post

### DIFF
--- a/telegram_auto_poster/client/client.py
+++ b/telegram_auto_poster/client/client.py
@@ -167,8 +167,7 @@ class TelegramMemeClient:
                     if request_id is not None:
                         await mark_channel_analytics_refresh_completed(request_id)
                     next_refresh_at = (
-                        time.monotonic()
-                        + CHANNEL_ANALYTICS_REFRESH_THRESHOLD_SECONDS
+                        time.monotonic() + CHANNEL_ANALYTICS_REFRESH_THRESHOLD_SECONDS
                     )
             except asyncio.CancelledError:  # pragma: no cover - task cancellation
                 raise

--- a/telegram_auto_poster/utils/jobs.py
+++ b/telegram_auto_poster/utils/jobs.py
@@ -949,7 +949,9 @@ async def _run_rebuild_dedup_hashes(context: JobRunContext) -> None:
     """Backfill the approved deduplication corpus from stored media objects."""
 
     objects = await storage.list_files(BUCKET_MAIN)
-    media_objects = [path for path in objects if _is_image_path(path) or _is_video_path(path)]
+    media_objects = [
+        path for path in objects if _is_image_path(path) or _is_video_path(path)
+    ]
     await context.replace_stats(
         {
             "objects_total": len(objects),
@@ -992,9 +994,13 @@ async def _run_rebuild_dedup_hashes(context: JobRunContext) -> None:
                 continue
 
             if _is_image_path(path):
-                media_hash = await asyncio.to_thread(calculate_image_hash, temp_path) or ""
+                media_hash = (
+                    await asyncio.to_thread(calculate_image_hash, temp_path) or ""
+                )
             elif _is_video_path(path):
-                media_hash = await asyncio.to_thread(calculate_video_hash, temp_path) or ""
+                media_hash = (
+                    await asyncio.to_thread(calculate_video_hash, temp_path) or ""
+                )
             else:
                 await context.increment("objects_skipped")
                 continue
@@ -1046,7 +1052,9 @@ async def _run_refresh_channel_analytics(context: JobRunContext) -> None:
             "channels_with_errors": 0,
         }
     )
-    await context.set_status_detail("Waiting for the Telethon client to refresh analytics")
+    await context.set_status_detail(
+        "Waiting for the Telethon client to refresh analytics"
+    )
 
     timeout_seconds = 30
     for waited in range(timeout_seconds + 1):

--- a/telegram_auto_poster/web/app.py
+++ b/telegram_auto_poster/web/app.py
@@ -381,12 +381,14 @@ def _media_kind(path: str, mime: str | None = None) -> str:
     """Return ``image`` or ``video`` based on object path and mime type."""
 
     guessed_mime = mime or mimetypes.guess_type(path)[0]
-    if path.startswith(f"{VIDEOS_PATH}/") or path.startswith(
-        f"{TRASH_PATH}/{VIDEOS_PATH}/"
+    if any(
+        path.startswith(prefix)
+        for prefix in (f"{VIDEOS_PATH}/", f"{TRASH_PATH}/{VIDEOS_PATH}/")
     ):
         return "video"
-    if path.startswith(f"{PHOTOS_PATH}/") or path.startswith(
-        f"{TRASH_PATH}/{PHOTOS_PATH}/"
+    if any(
+        path.startswith(prefix)
+        for prefix in (f"{PHOTOS_PATH}/", f"{TRASH_PATH}/{PHOTOS_PATH}/")
     ):
         return "image"
     if guessed_mime and guessed_mime.startswith("video/"):

--- a/telegram_auto_poster/web/app.py
+++ b/telegram_auto_poster/web/app.py
@@ -666,7 +666,9 @@ async def _get_cached_posts_summary_groups() -> list[dict[str, object]] | None:
     return None
 
 
-async def _store_cached_posts_summary_groups(groups: Sequence[dict[str, object]]) -> None:
+async def _store_cached_posts_summary_groups(
+    groups: Sequence[dict[str, object]],
+) -> None:
     """Persist summary groups for reuse across requests."""
 
     try:
@@ -1359,9 +1361,9 @@ async def _send_batch_now(request: Request) -> dict[str, object]:
     for post in posts:
         all_paths.extend(
             [
-            item["path"]
-            for item in post["items"]
-            if isinstance(item, dict) and isinstance(item.get("path"), str)
+                item["path"]
+                for item in post["items"]
+                if isinstance(item, dict) and isinstance(item.get("path"), str)
             ]
         )
 
@@ -1903,7 +1905,9 @@ async def api_suggestions(page: int = 1, sort: str = "newest") -> JSONResponse:
     sorted_suggestions = _sort_posts_groups(suggestions, sanitized_sort)
     count = len(sorted_suggestions)
     page, total_pages, offset = _paginate(count, page, ITEMS_PER_PAGE)
-    items = await _hydrate_post_groups(sorted_suggestions[offset : offset + ITEMS_PER_PAGE])
+    items = await _hydrate_post_groups(
+        sorted_suggestions[offset : offset + ITEMS_PER_PAGE]
+    )
     return JSONResponse(
         {
             "items": items,
@@ -1942,13 +1946,16 @@ async def api_posts(
             if isinstance(source_name, str) and source_name
         }
     )
-    filtered_posts = _sort_posts_groups(_filter_posts_groups(
-        posts,
-        query=normalized_query,
-        kind=sanitized_kind,
-        layout=sanitized_layout,
-        source=normalized_source,
-    ), sanitized_sort)
+    filtered_posts = _sort_posts_groups(
+        _filter_posts_groups(
+            posts,
+            query=normalized_query,
+            kind=sanitized_kind,
+            layout=sanitized_layout,
+            source=normalized_source,
+        ),
+        sanitized_sort,
+    )
     count = len(filtered_posts)
     page, total_pages, offset = _paginate(count, page, ITEMS_PER_PAGE)
     items = await _hydrate_post_groups(filtered_posts[offset : offset + ITEMS_PER_PAGE])

--- a/test/utils/test_db.py
+++ b/test/utils/test_db.py
@@ -55,7 +55,8 @@ def test_get_redis_client_imports_valkey(mocker):
 def test_schedule_roundtrip(mocker):
     fake = fakeredis.FakeRedis(decode_responses=True)
     mocker.patch("telegram_auto_poster.utils.db.get_redis_client", return_value=fake)
-    db.add_scheduled_post(100, "foo")
+    item_id = "foo"
+    db.add_scheduled_post(100, item_id)
     assert db.get_scheduled_posts() == [("foo", 100.0)]
     assert db.get_scheduled_time("foo") == 100
     db.remove_scheduled_post("foo")
@@ -88,23 +89,25 @@ async def test_clear_event_history(mock_async_redis):
     events = await db.get_event_history()
     assert events == []
 
+
 def test_add_scheduled_post(mocker):
     fake = fakeredis.FakeRedis(decode_responses=True)
     mocker.patch("telegram_auto_poster.utils.db.get_redis_client", return_value=fake)
 
     # Add a scheduled post
-    db.add_scheduled_post(100, "foo")
+    item_id = "foo"
+    db.add_scheduled_post(100, item_id)
 
     zset_key = db._redis_key("scheduled_posts", "schedule")
     hash_key = db._redis_key("scheduled_posts", "scheduled_at")
 
     # Verify internal state
-    assert fake.zscore(zset_key, "foo") == 100.0
-    assert fake.hget(hash_key, "foo") == "100"
+    assert fake.zscore(zset_key, item_id) == 100.0
+    assert fake.hget(hash_key, item_id) == "100"
 
     # Update the scheduled post
-    db.add_scheduled_post(200, "foo")
+    db.add_scheduled_post(200, item_id)
 
     # Verify updated internal state
-    assert fake.zscore(zset_key, "foo") == 200.0
-    assert fake.hget(hash_key, "foo") == "200"
+    assert fake.zscore(zset_key, item_id) == 200.0
+    assert fake.hget(hash_key, item_id) == "200"

--- a/test/utils/test_db.py
+++ b/test/utils/test_db.py
@@ -87,3 +87,24 @@ async def test_clear_event_history(mock_async_redis):
 
     events = await db.get_event_history()
     assert events == []
+
+def test_add_scheduled_post(mocker):
+    fake = fakeredis.FakeRedis(decode_responses=True)
+    mocker.patch("telegram_auto_poster.utils.db.get_redis_client", return_value=fake)
+
+    # Add a scheduled post
+    db.add_scheduled_post(100, "foo")
+
+    zset_key = db._redis_key("scheduled_posts", "schedule")
+    hash_key = db._redis_key("scheduled_posts", "scheduled_at")
+
+    # Verify internal state
+    assert fake.zscore(zset_key, "foo") == 100.0
+    assert fake.hget(hash_key, "foo") == "100"
+
+    # Update the scheduled post
+    db.add_scheduled_post(200, "foo")
+
+    # Verify updated internal state
+    assert fake.zscore(zset_key, "foo") == 200.0
+    assert fake.hget(hash_key, "foo") == "200"


### PR DESCRIPTION
🎯 **What:** 
Added a test (`test_add_scheduled_post`) to explicitly verify the internal Redis keys updated by `add_scheduled_post` in `telegram_auto_poster/utils/db.py`. Previously, `test_schedule_roundtrip` verified the integration with other `db` functions but didn't directly check the Redis state as described in the docstring of `add_scheduled_post`.

📊 **Coverage:** 
- Adding a new scheduled post: Verifies the `zset` and `hash` in Redis are accurately updated.
- Updating an existing scheduled post: Verifies both the `zset` and `hash` in Redis are overwritten with the new timestamp.

✨ **Result:** 
Increased coverage and robustness by explicitly testing internal behavior instead of merely testing output endpoints. Validated the happy paths of `add_scheduled_post` independently using `fakeredis` directly.

---
*PR created automatically by Jules for task [18313004011872092637](https://jules.google.com/task/18313004011872092637) started by @ooodnakov*