### PR TITLE
🧪 Add tests for logger_setup.py

### DIFF
--- a/telegram_auto_poster/client/client.py
+++ b/telegram_auto_poster/client/client.py
@@ -167,8 +167,7 @@ class TelegramMemeClient:
                     if request_id is not None:
                         await mark_channel_analytics_refresh_completed(request_id)
                     next_refresh_at = (
-                        time.monotonic()
-                        + CHANNEL_ANALYTICS_REFRESH_THRESHOLD_SECONDS
+                        time.monotonic() + CHANNEL_ANALYTICS_REFRESH_THRESHOLD_SECONDS
                     )
             except asyncio.CancelledError:  # pragma: no cover - task cancellation
                 raise

--- a/telegram_auto_poster/utils/jobs.py
+++ b/telegram_auto_poster/utils/jobs.py
@@ -949,7 +949,9 @@ async def _run_rebuild_dedup_hashes(context: JobRunContext) -> None:
     """Backfill the approved deduplication corpus from stored media objects."""
 
     objects = await storage.list_files(BUCKET_MAIN)
-    media_objects = [path for path in objects if _is_image_path(path) or _is_video_path(path)]
+    media_objects = [
+        path for path in objects if _is_image_path(path) or _is_video_path(path)
+    ]
     await context.replace_stats(
         {
             "objects_total": len(objects),
@@ -992,9 +994,13 @@ async def _run_rebuild_dedup_hashes(context: JobRunContext) -> None:
                 continue
 
             if _is_image_path(path):
-                media_hash = await asyncio.to_thread(calculate_image_hash, temp_path) or ""
+                media_hash = (
+                    await asyncio.to_thread(calculate_image_hash, temp_path) or ""
+                )
             elif _is_video_path(path):
-                media_hash = await asyncio.to_thread(calculate_video_hash, temp_path) or ""
+                media_hash = (
+                    await asyncio.to_thread(calculate_video_hash, temp_path) or ""
+                )
             else:
                 await context.increment("objects_skipped")
                 continue
@@ -1046,7 +1052,9 @@ async def _run_refresh_channel_analytics(context: JobRunContext) -> None:
             "channels_with_errors": 0,
         }
     )
-    await context.set_status_detail("Waiting for the Telethon client to refresh analytics")
+    await context.set_status_detail(
+        "Waiting for the Telethon client to refresh analytics"
+    )
 
     timeout_seconds = 30
     for waited in range(timeout_seconds + 1):

--- a/telegram_auto_poster/web/app.py
+++ b/telegram_auto_poster/web/app.py
@@ -666,7 +666,9 @@ async def _get_cached_posts_summary_groups() -> list[dict[str, object]] | None:
     return None
 
 
-async def _store_cached_posts_summary_groups(groups: Sequence[dict[str, object]]) -> None:
+async def _store_cached_posts_summary_groups(
+    groups: Sequence[dict[str, object]],
+) -> None:
     """Persist summary groups for reuse across requests."""
 
     try:
@@ -1359,9 +1361,9 @@ async def _send_batch_now(request: Request) -> dict[str, object]:
     for post in posts:
         all_paths.extend(
             [
-            item["path"]
-            for item in post["items"]
-            if isinstance(item, dict) and isinstance(item.get("path"), str)
+                item["path"]
+                for item in post["items"]
+                if isinstance(item, dict) and isinstance(item.get("path"), str)
             ]
         )
 
@@ -1903,7 +1905,9 @@ async def api_suggestions(page: int = 1, sort: str = "newest") -> JSONResponse:
     sorted_suggestions = _sort_posts_groups(suggestions, sanitized_sort)
     count = len(sorted_suggestions)
     page, total_pages, offset = _paginate(count, page, ITEMS_PER_PAGE)
-    items = await _hydrate_post_groups(sorted_suggestions[offset : offset + ITEMS_PER_PAGE])
+    items = await _hydrate_post_groups(
+        sorted_suggestions[offset : offset + ITEMS_PER_PAGE]
+    )
     return JSONResponse(
         {
             "items": items,
@@ -1942,13 +1946,16 @@ async def api_posts(
             if isinstance(source_name, str) and source_name
         }
     )
-    filtered_posts = _sort_posts_groups(_filter_posts_groups(
-        posts,
-        query=normalized_query,
-        kind=sanitized_kind,
-        layout=sanitized_layout,
-        source=normalized_source,
-    ), sanitized_sort)
+    filtered_posts = _sort_posts_groups(
+        _filter_posts_groups(
+            posts,
+            query=normalized_query,
+            kind=sanitized_kind,
+            layout=sanitized_layout,
+            source=normalized_source,
+        ),
+        sanitized_sort,
+    )
     count = len(filtered_posts)
     page, total_pages, offset = _paginate(count, page, ITEMS_PER_PAGE)
     items = await _hydrate_post_groups(filtered_posts[offset : offset + ITEMS_PER_PAGE])

--- a/test/utils/test_logger_setup.py
+++ b/test/utils/test_logger_setup.py
@@ -1,0 +1,89 @@
+import logging
+import sys
+from typing import Any, Mapping
+
+from pytest_mock import MockerFixture
+
+from telegram_auto_poster.utils.logger_setup import (
+    PropagateHandler,
+    custom_format,
+    setup_logger,
+)
+
+
+def test_custom_format() -> None:
+    """Test that custom_format returns the expected string with relative path."""
+
+    class FakeFile:
+        def __init__(self, path: str):
+            self.path = path
+
+    record: Mapping[str, Any] = {"file": FakeFile("/some/absolute/path.py")}
+
+    result = custom_format(record)
+
+    # Path should have the first character stripped (e.g. "/some/..." -> "some/...")
+    expected_path_segment = "some/absolute/path.py"
+
+    assert f"<cyan>{expected_path_segment}</cyan>" in result
+    assert "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green>" in result
+    assert "<level>{message}</level>" in result
+
+
+def test_custom_format_no_path() -> None:
+    """Test custom_format when record does not have a valid file path."""
+    record: Mapping[str, Any] = {"file": None}
+    result = custom_format(record)
+    assert "<cyan></cyan>:<cyan>{line}</cyan>" in result
+
+
+def test_propagate_handler(mocker: MockerFixture) -> None:
+    """Test that PropagateHandler forwards loguru records to standard logging."""
+    handler = PropagateHandler()
+    record = logging.LogRecord(
+        name="test_logger",
+        level=logging.INFO,
+        pathname="path.py",
+        lineno=10,
+        msg="test message",
+        args=(),
+        exc_info=None,
+    )
+
+    mock_logger = mocker.Mock()
+    mock_get_logger = mocker.patch("logging.getLogger", return_value=mock_logger)
+
+    handler.emit(record)
+
+    mock_get_logger.assert_called_once_with("test_logger")
+    mock_logger.handle.assert_called_once_with(record)
+
+
+def test_setup_logger(mocker: MockerFixture) -> None:
+    """Test that setup_logger configures loguru correctly."""
+    mock_remove = mocker.patch("telegram_auto_poster.utils.logger_setup.logger.remove")
+    mock_add = mocker.patch("telegram_auto_poster.utils.logger_setup.logger.add")
+
+    logger_instance = setup_logger()
+
+    # Assert logger.remove() was called to clear defaults
+    mock_remove.assert_called_once_with()
+
+    # Assert logger.add() was called twice: once for stderr, once for PropagateHandler
+    assert mock_add.call_count == 2
+
+    # Check stderr handler
+    call_args_1 = mock_add.call_args_list[0]
+    assert call_args_1.args[0] is sys.stderr
+    assert call_args_1.kwargs.get("format") == custom_format
+    assert call_args_1.kwargs.get("colorize") is True
+
+    # Check PropagateHandler
+    call_args_2 = mock_add.call_args_list[1]
+    assert isinstance(call_args_2.args[0], PropagateHandler)
+    assert call_args_2.kwargs.get("format") == "{message}"
+
+    # Make sure it returns the logger
+    from loguru import logger as expected_logger
+
+    assert logger_instance is expected_logger


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was a lack of unit tests for the application's logging setup utilities in `telegram_auto_poster/utils/logger_setup.py`.

📊 **Coverage:** The new tests cover:
- `custom_format` (normal usage with valid paths and edge case with missing file path)
- `PropagateHandler` (ensuring that loguru records are forwarded to the standard Python `logging` module)
- `setup_logger` (verifying proper handler removal and addition of colored stderr logging plus propagation)

✨ **Result:** Test coverage for the internal application state and log utilities has significantly improved, ensuring configuration code can be refactored with confidence.

---
*PR created automatically by Jules for task [14725672786566338742](https://jules.google.com/task/14725672786566338742) started by @ooodnakov*