### PR TITLE
🧪 Improve tests for backoff_delay function

### DIFF
--- a/telegram_auto_poster/client/client.py
+++ b/telegram_auto_poster/client/client.py
@@ -167,8 +167,7 @@ class TelegramMemeClient:
                     if request_id is not None:
                         await mark_channel_analytics_refresh_completed(request_id)
                     next_refresh_at = (
-                        time.monotonic()
-                        + CHANNEL_ANALYTICS_REFRESH_THRESHOLD_SECONDS
+                        time.monotonic() + CHANNEL_ANALYTICS_REFRESH_THRESHOLD_SECONDS
                     )
             except asyncio.CancelledError:  # pragma: no cover - task cancellation
                 raise

--- a/telegram_auto_poster/utils/jobs.py
+++ b/telegram_auto_poster/utils/jobs.py
@@ -949,7 +949,9 @@ async def _run_rebuild_dedup_hashes(context: JobRunContext) -> None:
     """Backfill the approved deduplication corpus from stored media objects."""
 
     objects = await storage.list_files(BUCKET_MAIN)
-    media_objects = [path for path in objects if _is_image_path(path) or _is_video_path(path)]
+    media_objects = [
+        path for path in objects if _is_image_path(path) or _is_video_path(path)
+    ]
     await context.replace_stats(
         {
             "objects_total": len(objects),
@@ -992,9 +994,13 @@ async def _run_rebuild_dedup_hashes(context: JobRunContext) -> None:
                 continue
 
             if _is_image_path(path):
-                media_hash = await asyncio.to_thread(calculate_image_hash, temp_path) or ""
+                media_hash = (
+                    await asyncio.to_thread(calculate_image_hash, temp_path) or ""
+                )
             elif _is_video_path(path):
-                media_hash = await asyncio.to_thread(calculate_video_hash, temp_path) or ""
+                media_hash = (
+                    await asyncio.to_thread(calculate_video_hash, temp_path) or ""
+                )
             else:
                 await context.increment("objects_skipped")
                 continue
@@ -1046,7 +1052,9 @@ async def _run_refresh_channel_analytics(context: JobRunContext) -> None:
             "channels_with_errors": 0,
         }
     )
-    await context.set_status_detail("Waiting for the Telethon client to refresh analytics")
+    await context.set_status_detail(
+        "Waiting for the Telethon client to refresh analytics"
+    )
 
     timeout_seconds = 30
     for waited in range(timeout_seconds + 1):

--- a/telegram_auto_poster/web/app.py
+++ b/telegram_auto_poster/web/app.py
@@ -666,7 +666,9 @@ async def _get_cached_posts_summary_groups() -> list[dict[str, object]] | None:
     return None
 
 
-async def _store_cached_posts_summary_groups(groups: Sequence[dict[str, object]]) -> None:
+async def _store_cached_posts_summary_groups(
+    groups: Sequence[dict[str, object]],
+) -> None:
     """Persist summary groups for reuse across requests."""
 
     try:
@@ -1359,9 +1361,9 @@ async def _send_batch_now(request: Request) -> dict[str, object]:
     for post in posts:
         all_paths.extend(
             [
-            item["path"]
-            for item in post["items"]
-            if isinstance(item, dict) and isinstance(item.get("path"), str)
+                item["path"]
+                for item in post["items"]
+                if isinstance(item, dict) and isinstance(item.get("path"), str)
             ]
         )
 
@@ -1903,7 +1905,9 @@ async def api_suggestions(page: int = 1, sort: str = "newest") -> JSONResponse:
     sorted_suggestions = _sort_posts_groups(suggestions, sanitized_sort)
     count = len(sorted_suggestions)
     page, total_pages, offset = _paginate(count, page, ITEMS_PER_PAGE)
-    items = await _hydrate_post_groups(sorted_suggestions[offset : offset + ITEMS_PER_PAGE])
+    items = await _hydrate_post_groups(
+        sorted_suggestions[offset : offset + ITEMS_PER_PAGE]
+    )
     return JSONResponse(
         {
             "items": items,
@@ -1942,13 +1946,16 @@ async def api_posts(
             if isinstance(source_name, str) and source_name
         }
     )
-    filtered_posts = _sort_posts_groups(_filter_posts_groups(
-        posts,
-        query=normalized_query,
-        kind=sanitized_kind,
-        layout=sanitized_layout,
-        source=normalized_source,
-    ), sanitized_sort)
+    filtered_posts = _sort_posts_groups(
+        _filter_posts_groups(
+            posts,
+            query=normalized_query,
+            kind=sanitized_kind,
+            layout=sanitized_layout,
+            source=normalized_source,
+        ),
+        sanitized_sort,
+    )
     count = len(filtered_posts)
     page, total_pages, offset = _paginate(count, page, ITEMS_PER_PAGE)
     items = await _hydrate_post_groups(filtered_posts[offset : offset + ITEMS_PER_PAGE])

--- a/test/utils/test_client_resilience.py
+++ b/test/utils/test_client_resilience.py
@@ -29,7 +29,7 @@ def test_backoff_delay_jitter(mock_uniform):
     mock_uniform.return_value = 0.15
     delay = backoff_delay(2, base=1.0, cap=5.0, jitter=0.1)
     mock_uniform.assert_called_once_with(-0.2, 0.2)
-    assert delay == 2.15
+    assert delay == pytest.approx(2.15)
 
 
 @patch("telegram_auto_poster.utils.general.random.uniform")
@@ -38,7 +38,7 @@ def test_backoff_delay_negative_jitter(mock_uniform):
     mock_uniform.return_value = -0.15
     delay = backoff_delay(2, base=1.0, cap=5.0, jitter=0.1)
     mock_uniform.assert_called_once_with(-0.2, 0.2)
-    assert delay == 1.85
+    assert delay == pytest.approx(1.85)
 
 
 @pytest.mark.asyncio

--- a/test/utils/test_client_resilience.py
+++ b/test/utils/test_client_resilience.py
@@ -1,16 +1,44 @@
 import pytest
+from unittest.mock import patch
 from telegram_auto_poster.utils.general import RateLimiter, backoff_delay
 
 
+def test_backoff_delay_exponential_growth():
+    # Test that the delay grows exponentially: 1, 2, 4, 8, 16...
+    delays = [backoff_delay(i, base=1.0, cap=100.0, jitter=0.0) for i in range(1, 6)]
+    assert delays == [1.0, 2.0, 4.0, 8.0, 16.0]
+
+
 def test_backoff_delay_cap():
-    delays = [backoff_delay(i, base=1, cap=5, jitter=0) for i in range(1, 10)]
-    assert delays[0] == 1
-    assert delays[-1] == 5
+    # Test that the delay is capped
+    delays = [backoff_delay(i, base=1.0, cap=5.0, jitter=0.0) for i in range(1, 6)]
+    assert delays == [1.0, 2.0, 4.0, 5.0, 5.0]
 
 
-def test_backoff_delay_jitter():
-    delay = backoff_delay(2, base=1, cap=5, jitter=0.1)
-    assert 1.8 <= delay <= 2.2
+def test_backoff_delay_base_and_cap():
+    # Test with different base and cap
+    delays = [backoff_delay(i, base=2.0, cap=10.0, jitter=0.0) for i in range(1, 5)]
+    assert delays == [2.0, 4.0, 8.0, 10.0]
+
+
+@patch("telegram_auto_poster.utils.general.random.uniform")
+def test_backoff_delay_jitter(mock_uniform):
+    # Base delay for retry=2 is 1 * 2**(2-1) = 2.0
+    # Jitter range is 2.0 * 0.1 = 0.2
+    # Delay will be 2.0 + random.uniform(-0.2, 0.2)
+    mock_uniform.return_value = 0.15
+    delay = backoff_delay(2, base=1.0, cap=5.0, jitter=0.1)
+    mock_uniform.assert_called_once_with(-0.2, 0.2)
+    assert delay == 2.15
+
+
+@patch("telegram_auto_poster.utils.general.random.uniform")
+def test_backoff_delay_negative_jitter(mock_uniform):
+    # Same base delay, testing negative uniform value
+    mock_uniform.return_value = -0.15
+    delay = backoff_delay(2, base=1.0, cap=5.0, jitter=0.1)
+    mock_uniform.assert_called_once_with(-0.2, 0.2)
+    assert delay == 1.85
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
🎯 What: Replaced basic non-deterministic backoff delay tests with comprehensive tests in `test_client_resilience.py`
📊 Coverage: Now explicitly checking exponential growth, custom caps, custom bases, positive jitter and negative jitter using mocking to remove flakiness.
✨ Result: The backoff_delay function test coverage is now robust, fully deterministic, and extensively documents the behavior of exponential backoff caps and jitter.

---
*PR created automatically by Jules for task [10152640628195666595](https://jules.google.com/task/10152640628195666595) started by @ooodnakov*