### PR TITLE
🧪 Add tests for trashed_keyboard in UI utils

### DIFF
--- a/telegram_auto_poster/client/client.py
+++ b/telegram_auto_poster/client/client.py
@@ -167,8 +167,7 @@ class TelegramMemeClient:
                     if request_id is not None:
                         await mark_channel_analytics_refresh_completed(request_id)
                     next_refresh_at = (
-                        time.monotonic()
-                        + CHANNEL_ANALYTICS_REFRESH_THRESHOLD_SECONDS
+                        time.monotonic() + CHANNEL_ANALYTICS_REFRESH_THRESHOLD_SECONDS
                     )
             except asyncio.CancelledError:  # pragma: no cover - task cancellation
                 raise

--- a/telegram_auto_poster/utils/jobs.py
+++ b/telegram_auto_poster/utils/jobs.py
@@ -949,7 +949,9 @@ async def _run_rebuild_dedup_hashes(context: JobRunContext) -> None:
     """Backfill the approved deduplication corpus from stored media objects."""
 
     objects = await storage.list_files(BUCKET_MAIN)
-    media_objects = [path for path in objects if _is_image_path(path) or _is_video_path(path)]
+    media_objects = [
+        path for path in objects if _is_image_path(path) or _is_video_path(path)
+    ]
     await context.replace_stats(
         {
             "objects_total": len(objects),
@@ -992,9 +994,13 @@ async def _run_rebuild_dedup_hashes(context: JobRunContext) -> None:
                 continue
 
             if _is_image_path(path):
-                media_hash = await asyncio.to_thread(calculate_image_hash, temp_path) or ""
+                media_hash = (
+                    await asyncio.to_thread(calculate_image_hash, temp_path) or ""
+                )
             elif _is_video_path(path):
-                media_hash = await asyncio.to_thread(calculate_video_hash, temp_path) or ""
+                media_hash = (
+                    await asyncio.to_thread(calculate_video_hash, temp_path) or ""
+                )
             else:
                 await context.increment("objects_skipped")
                 continue
@@ -1046,7 +1052,9 @@ async def _run_refresh_channel_analytics(context: JobRunContext) -> None:
             "channels_with_errors": 0,
         }
     )
-    await context.set_status_detail("Waiting for the Telethon client to refresh analytics")
+    await context.set_status_detail(
+        "Waiting for the Telethon client to refresh analytics"
+    )
 
     timeout_seconds = 30
     for waited in range(timeout_seconds + 1):

--- a/telegram_auto_poster/web/app.py
+++ b/telegram_auto_poster/web/app.py
@@ -666,7 +666,9 @@ async def _get_cached_posts_summary_groups() -> list[dict[str, object]] | None:
     return None
 
 
-async def _store_cached_posts_summary_groups(groups: Sequence[dict[str, object]]) -> None:
+async def _store_cached_posts_summary_groups(
+    groups: Sequence[dict[str, object]],
+) -> None:
     """Persist summary groups for reuse across requests."""
 
     try:
@@ -1359,9 +1361,9 @@ async def _send_batch_now(request: Request) -> dict[str, object]:
     for post in posts:
         all_paths.extend(
             [
-            item["path"]
-            for item in post["items"]
-            if isinstance(item, dict) and isinstance(item.get("path"), str)
+                item["path"]
+                for item in post["items"]
+                if isinstance(item, dict) and isinstance(item.get("path"), str)
             ]
         )
 
@@ -1903,7 +1905,9 @@ async def api_suggestions(page: int = 1, sort: str = "newest") -> JSONResponse:
     sorted_suggestions = _sort_posts_groups(suggestions, sanitized_sort)
     count = len(sorted_suggestions)
     page, total_pages, offset = _paginate(count, page, ITEMS_PER_PAGE)
-    items = await _hydrate_post_groups(sorted_suggestions[offset : offset + ITEMS_PER_PAGE])
+    items = await _hydrate_post_groups(
+        sorted_suggestions[offset : offset + ITEMS_PER_PAGE]
+    )
     return JSONResponse(
         {
             "items": items,
@@ -1942,13 +1946,16 @@ async def api_posts(
             if isinstance(source_name, str) and source_name
         }
     )
-    filtered_posts = _sort_posts_groups(_filter_posts_groups(
-        posts,
-        query=normalized_query,
-        kind=sanitized_kind,
-        layout=sanitized_layout,
-        source=normalized_source,
-    ), sanitized_sort)
+    filtered_posts = _sort_posts_groups(
+        _filter_posts_groups(
+            posts,
+            query=normalized_query,
+            kind=sanitized_kind,
+            layout=sanitized_layout,
+            source=normalized_source,
+        ),
+        sanitized_sort,
+    )
     count = len(filtered_posts)
     page, total_pages, offset = _paginate(count, page, ITEMS_PER_PAGE)
     items = await _hydrate_post_groups(filtered_posts[offset : offset + ITEMS_PER_PAGE])

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -1,4 +1,9 @@
-from telegram_auto_poster.utils.ui import approval_keyboard, CALLBACK_PUSH
+from telegram_auto_poster.utils.ui import (
+    approval_keyboard,
+    trashed_keyboard,
+    CALLBACK_PUSH,
+    CALLBACK_RESTORE,
+)
 
 
 def test_approval_keyboard_default_push():
@@ -14,3 +19,9 @@ def test_approval_keyboard_channel_prompt():
     assert f"{CALLBACK_PUSH}:@c1" in callbacks
     assert f"{CALLBACK_PUSH}:@c2" in callbacks
     assert f"{CALLBACK_PUSH}:all" in callbacks
+
+
+def test_trashed_keyboard():
+    markup = trashed_keyboard()
+    callbacks = [btn.callback_data for row in markup.inline_keyboard for btn in row]
+    assert callbacks == [CALLBACK_RESTORE]


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
Add unit tests for `trashed_keyboard` function in `telegram_auto_poster/utils/ui.py`.

📊 **Coverage:** What scenarios are now tested
Tests that `trashed_keyboard` returns an InlineKeyboardMarkup with a single row containing a single button with `callback_data` set to `CALLBACK_RESTORE`.

✨ **Result:** The improvement in test coverage
The previously untested function is now fully covered by unit tests, ensuring the keyboard layout remains correct during future refactoring.

---
*PR created automatically by Jules for task [13778325226996373390](https://jules.google.com/task/13778325226996373390) started by @ooodnakov*