### PR TITLE
🧪 Add tests for get_async_redis_client in utils/db.py

### DIFF
--- a/telegram_auto_poster/client/client.py
+++ b/telegram_auto_poster/client/client.py
@@ -167,8 +167,7 @@ class TelegramMemeClient:
                     if request_id is not None:
                         await mark_channel_analytics_refresh_completed(request_id)
                     next_refresh_at = (
-                        time.monotonic()
-                        + CHANNEL_ANALYTICS_REFRESH_THRESHOLD_SECONDS
+                        time.monotonic() + CHANNEL_ANALYTICS_REFRESH_THRESHOLD_SECONDS
                     )
             except asyncio.CancelledError:  # pragma: no cover - task cancellation
                 raise

--- a/telegram_auto_poster/utils/jobs.py
+++ b/telegram_auto_poster/utils/jobs.py
@@ -949,7 +949,9 @@ async def _run_rebuild_dedup_hashes(context: JobRunContext) -> None:
     """Backfill the approved deduplication corpus from stored media objects."""
 
     objects = await storage.list_files(BUCKET_MAIN)
-    media_objects = [path for path in objects if _is_image_path(path) or _is_video_path(path)]
+    media_objects = [
+        path for path in objects if _is_image_path(path) or _is_video_path(path)
+    ]
     await context.replace_stats(
         {
             "objects_total": len(objects),
@@ -992,9 +994,13 @@ async def _run_rebuild_dedup_hashes(context: JobRunContext) -> None:
                 continue
 
             if _is_image_path(path):
-                media_hash = await asyncio.to_thread(calculate_image_hash, temp_path) or ""
+                media_hash = (
+                    await asyncio.to_thread(calculate_image_hash, temp_path) or ""
+                )
             elif _is_video_path(path):
-                media_hash = await asyncio.to_thread(calculate_video_hash, temp_path) or ""
+                media_hash = (
+                    await asyncio.to_thread(calculate_video_hash, temp_path) or ""
+                )
             else:
                 await context.increment("objects_skipped")
                 continue
@@ -1046,7 +1052,9 @@ async def _run_refresh_channel_analytics(context: JobRunContext) -> None:
             "channels_with_errors": 0,
         }
     )
-    await context.set_status_detail("Waiting for the Telethon client to refresh analytics")
+    await context.set_status_detail(
+        "Waiting for the Telethon client to refresh analytics"
+    )
 
     timeout_seconds = 30
     for waited in range(timeout_seconds + 1):

--- a/telegram_auto_poster/web/app.py
+++ b/telegram_auto_poster/web/app.py
@@ -666,7 +666,9 @@ async def _get_cached_posts_summary_groups() -> list[dict[str, object]] | None:
     return None
 
 
-async def _store_cached_posts_summary_groups(groups: Sequence[dict[str, object]]) -> None:
+async def _store_cached_posts_summary_groups(
+    groups: Sequence[dict[str, object]],
+) -> None:
     """Persist summary groups for reuse across requests."""
 
     try:
@@ -1359,9 +1361,9 @@ async def _send_batch_now(request: Request) -> dict[str, object]:
     for post in posts:
         all_paths.extend(
             [
-            item["path"]
-            for item in post["items"]
-            if isinstance(item, dict) and isinstance(item.get("path"), str)
+                item["path"]
+                for item in post["items"]
+                if isinstance(item, dict) and isinstance(item.get("path"), str)
             ]
         )
 
@@ -1903,7 +1905,9 @@ async def api_suggestions(page: int = 1, sort: str = "newest") -> JSONResponse:
     sorted_suggestions = _sort_posts_groups(suggestions, sanitized_sort)
     count = len(sorted_suggestions)
     page, total_pages, offset = _paginate(count, page, ITEMS_PER_PAGE)
-    items = await _hydrate_post_groups(sorted_suggestions[offset : offset + ITEMS_PER_PAGE])
+    items = await _hydrate_post_groups(
+        sorted_suggestions[offset : offset + ITEMS_PER_PAGE]
+    )
     return JSONResponse(
         {
             "items": items,
@@ -1942,13 +1946,16 @@ async def api_posts(
             if isinstance(source_name, str) and source_name
         }
     )
-    filtered_posts = _sort_posts_groups(_filter_posts_groups(
-        posts,
-        query=normalized_query,
-        kind=sanitized_kind,
-        layout=sanitized_layout,
-        source=normalized_source,
-    ), sanitized_sort)
+    filtered_posts = _sort_posts_groups(
+        _filter_posts_groups(
+            posts,
+            query=normalized_query,
+            kind=sanitized_kind,
+            layout=sanitized_layout,
+            source=normalized_source,
+        ),
+        sanitized_sort,
+    )
     count = len(filtered_posts)
     page, total_pages, offset = _paginate(count, page, ITEMS_PER_PAGE)
     items = await _hydrate_post_groups(filtered_posts[offset : offset + ITEMS_PER_PAGE])

--- a/test/utils/test_db.py
+++ b/test/utils/test_db.py
@@ -87,3 +87,21 @@ async def test_clear_event_history(mock_async_redis):
 
     events = await db.get_event_history()
     assert events == []
+
+
+def test_get_async_redis_client_imports_valkey(mocker):
+    mocker.patch("valkey.asyncio.Valkey", fakeredis.aioredis.FakeRedis)
+    mocker.patch.object(CONFIG.valkey.password, "get_secret_value", return_value=None)
+    mocker.patch.object(db, "_async_redis_client", None)
+    mocker.patch.object(db, "AsyncValkey", None)
+    client = db.get_async_redis_client()
+    assert isinstance(client, fakeredis.aioredis.FakeRedis)
+
+
+def test_get_async_redis_client_singleton(mocker):
+    mocker.patch("valkey.asyncio.Valkey", fakeredis.aioredis.FakeRedis)
+    mocker.patch.object(CONFIG.valkey.password, "get_secret_value", return_value=None)
+    mocker.patch.object(db, "_async_redis_client", None)
+    client1 = db.get_async_redis_client()
+    client2 = db.get_async_redis_client()
+    assert client1 is client2


### PR DESCRIPTION
🎯 What: Added tests for the asynchronous setup and mocking of get_async_redis_client.
📊 Coverage: Tested lazy importing of Valkey and initialization, as well as the singleton pattern to ensure consecutive calls return the same instance.
✨ Result: Improved overall test coverage for the db module, specifically addressing asynchronous redis client initialization.

---
*PR created automatically by Jules for task [15744682742285819214](https://jules.google.com/task/15744682742285819214) started by @ooodnakov*