### PR TITLE
Lock down pydoc route

### DIFF
--- a/telegram_auto_poster/web/app.py
+++ b/telegram_auto_poster/web/app.py
@@ -104,7 +104,7 @@ SPA_PUBLIC_PATHS = {
     "/robots.txt",
     "/placeholder.svg",
 }
-SPA_PUBLIC_PREFIXES = ("/assets", "/pydoc")
+SPA_PUBLIC_PREFIXES = ("/assets",)
 SPA_RESERVED_PREFIXES = ("api/", "assets/", "pydoc/")
 SPA_RESERVED_PATHS = {
     "auth",
@@ -2401,7 +2401,7 @@ async def placeholder() -> Response:
 
 @app.get("/pydoc/{module:path}", response_class=HTMLResponse)
 async def render_pydoc(module: str = "") -> HTMLResponse:
-    """Serve pydoc-generated documentation for the given module."""
+    """Serve admin-only pydoc-generated documentation for the given module."""
 
     if module and not module.startswith("telegram_auto_poster"):
         return HTMLResponse(

--- a/test/web/test_web_app.py
+++ b/test/web/test_web_app.py
@@ -22,6 +22,22 @@ def test_login_shell_is_public():
         assert 'id="root"' in resp.text
 
 
+def test_pydoc_requires_login_redirect():
+    with TestClient(app) as client:
+        resp = client.get(
+            "/pydoc/telegram_auto_poster.web.app", follow_redirects=False
+        )
+        assert resp.status_code == 303
+        assert resp.headers["location"] == "/login"
+        assert "Administrative dashboard API" not in resp.text
+
+
+def test_authenticated_admin_pydoc_route_serves_docs(auth_client: TestClient):
+    resp = auth_client.get("/pydoc/telegram_auto_poster.web.app")
+    assert resp.status_code == 200
+    assert "telegram_auto_poster.web.app" in resp.text
+
+
 def test_auth_post_sets_session_cookie():
     with TestClient(app) as client:
         payload = login_payload(CONFIG.bot.admin_ids[0])


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated users from browsing internally generated `pydoc` documentation by ensuring the SPA public prefix allowlist no longer exposes `/pydoc`.

### Description
- Remove `"/pydoc"` from `SPA_PUBLIC_PREFIXES` in `telegram_auto_poster/web/app.py` so the existing `AuthMiddleware` enforces session checks for `/pydoc`. 
- Update the `/pydoc/{module:path}` route docstring to clarify it is admin-only. 
- Add tests in `test/web/test_web_app.py` that assert unauthenticated requests to `/pydoc/...` redirect to `/login` and authenticated admin requests can still retrieve pydoc output.

### Testing
- Ran lint checks with `uv run ruff check telegram_auto_poster/web/app.py test/web/test_web_app.py` which passed. 
- Ran the focused tests with `uv run pytest test/web/test_web_app.py` which passed (14 passed). 
- Ran the full backend test suite with `uv run pytest -n auto` which passed (all tests passed: 241 passed, 1 skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5ac278a3fc83239a8b7aff05719bf9)